### PR TITLE
style(monarch.css): Add monospace default for code

### DIFF
--- a/website/monarch/monarch.css
+++ b/website/monarch/monarch.css
@@ -201,7 +201,7 @@ pre   { border: 1px solid #888
       }
 
 
-code, pre,dt { font-family: Consolas }
+code, pre,dt { font-family: Consolas, monospace }
 
 strong    { color: black }
 


### PR DESCRIPTION
Not every OS has `Consolas` as an installed font, for those browsers, default to `monospace`.

Previously:
![image](https://cloud.githubusercontent.com/assets/2925395/17301081/deaa70f0-57da-11e6-8e1c-f3aa9efb5eed.png)
