### PR TITLE
Update custom-languages playground sample to use SnippetString

### DIFF
--- a/test/playground.generated/extending-language-services-custom-languages.html
+++ b/test/playground.generated/extending-language-services-custom-languages.html
@@ -73,18 +73,22 @@ monaco.languages.registerCompletionItemProvider('mySpecialLanguage', {
 			}, {
 				label: 'testing',
 				kind: monaco.languages.CompletionItemKind.Keyword,
-				insertText:'testing({{condition}})'
+				insertText: {
+					value: 'testing(${1:condition})'
+				}
 			},
 			{
 				label: 'ifelse',
 				kind: monaco.languages.CompletionItemKind.Snippet,
-				insertText: [
-					'if ({{condition}}) {',
-					'\t{{}}',
-					'} else {',
-					'\t',
-					'}'
-				].join('\n'),
+				insertText: {
+					value: [
+						'if (${1:condition}) {',
+						'\t$0',
+						'} else {',
+						'\t',
+						'}'
+					].join('\n')
+				},
 				documentation: 'If-Else Statement'
 			}
 		]

--- a/website/playground/new-samples/extending-language-services/custom-languages/sample.js
+++ b/website/playground/new-samples/extending-language-services/custom-languages/sample.js
@@ -35,18 +35,22 @@ monaco.languages.registerCompletionItemProvider('mySpecialLanguage', {
 			}, {
 				label: 'testing',
 				kind: monaco.languages.CompletionItemKind.Keyword,
-				insertText:'testing({{condition}})'
+				insertText: {
+					value: 'testing(${1:condition})'
+				}
 			},
 			{
 				label: 'ifelse',
 				kind: monaco.languages.CompletionItemKind.Snippet,
-				insertText: [
-					'if ({{condition}}) {',
-					'\t{{}}',
-					'} else {',
-					'\t',
-					'}'
-				].join('\n'),
+				insertText: {
+					value: [
+						'if (${1:condition}) {',
+						'\t$0',
+						'} else {',
+						'\t',
+						'}'
+					].join('\n')
+				},
 				documentation: 'If-Else Statement'
 			}
 		]


### PR DESCRIPTION
Since the 0.9.0 release, the monaco-editor no longer supports the build-in snippet syntax. 

This PR updates the playground samples to use SnippetString and updates the syntax of the snippets to use the TextMate syntax described here: https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax
