### PR TITLE
Fix `Configure JSON defaults` sample

### DIFF
--- a/test/playground.generated/extending-language-services-configure-json-defaults.html
+++ b/test/playground.generated/extending-language-services-configure-json-defaults.html
@@ -38,9 +38,13 @@ loadEditor(function() {
 
 // Configures two JSON schemas, with references.
 
+var id = "foo.json";
+
 monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+	validate: true,
 	schemas: [{
         uri: "http://myserver/foo-schema.json",
+        fileMatch: [id],
         schema: {
             type: "object",
             properties: {
@@ -54,6 +58,7 @@ monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
         }
     },{
         uri: "http://myserver/bar-schema.json",
+        fileMatch: [id],
         schema: {
             type: "object",
             properties: {
@@ -68,14 +73,17 @@ monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
 
 var jsonCode = [
 	'{',
-	'    "$schema": "http://myserver/foo-schema.json"',
+	'    "p1": "v3",',
+	'    "p2": false',
 	"}"
 ].join('\n');
 
+var model = monaco.editor.createModel(jsonCode, "json", id);
+
 monaco.editor.create(document.getElementById("container"), {
-	value: jsonCode,
-	language: "json"
+	model: model
 });
+
 
 /*----------------------------------------SAMPLE CSS END*/
 });

--- a/website/playground/new-samples/extending-language-services/configure-json-defaults/sample.js
+++ b/website/playground/new-samples/extending-language-services/configure-json-defaults/sample.js
@@ -1,8 +1,12 @@
 // Configures two JSON schemas, with references.
 
+var id = "foo.json";
+
 monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+	validate: true,
 	schemas: [{
         uri: "http://myserver/foo-schema.json",
+        fileMatch: [id],
         schema: {
             type: "object",
             properties: {
@@ -16,6 +20,7 @@ monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
         }
     },{
         uri: "http://myserver/bar-schema.json",
+        fileMatch: [id],
         schema: {
             type: "object",
             properties: {
@@ -30,11 +35,13 @@ monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
 
 var jsonCode = [
 	'{',
-	'    "$schema": "http://myserver/foo-schema.json"',
+	'    "p1": "v3",',
+	'    "p2": false',
 	"}"
 ].join('\n');
 
+var model = monaco.editor.createModel(jsonCode, "json", id);
+
 monaco.editor.create(document.getElementById("container"), {
-	value: jsonCode,
-	language: "json"
+	model: model
 });


### PR DESCRIPTION
The [Configure JSON defaults sample](https://microsoft.github.io/monaco-editor/playground.html#extending-language-services-configure-json-defaults) in the playground is currently broken. Validation errors never show up even when the JSON doesn't conform to the schema.

<img width="271" alt="screen shot 2018-02-20 at 20 15 52" src="https://user-images.githubusercontent.com/4495237/36458068-092bd084-167b-11e8-8aa2-85abef06ce97.png">

Here's what I had to change to get it to work:
* Set `validate` to `true` in diagnostic options.
* Create a model; for each schema, set `fileMatch` to a value that matches the `uri` used when creating the model. Reference: https://github.com/Microsoft/monaco-editor/issues/191#issuecomment-248034168

I also changed the initial JSON so that the validation errors show up without editing the JSON.

### Test Plan
Ran `gulp simpleserver`. The validation errors now show up as expected.

<img width="271" alt="screen shot 2018-02-20 at 20 16 46" src="https://user-images.githubusercontent.com/4495237/36458075-171e3e66-167b-11e8-8c90-6afae41eb1b7.png">
