### PR TITLE
Add webpack loader plugin to simplify ESM usage

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,6 +54,9 @@ gulp.task('release', ['clean-release'], function() {
 		// min-maps folder
 		gulp.src('node_modules/monaco-editor-core/min-maps/**/*').pipe(gulp.dest('release/min-maps')),
 
+		// webpack plugin
+		gulp.src('webpack/**/*').pipe(gulp.dest('release/webpack')),
+
 		// other files
 		gulp.src([
 			'node_modules/monaco-editor-core/LICENSE',

--- a/package-lock.json
+++ b/package-lock.json
@@ -272,6 +272,232 @@
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
+    "babel-core": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.1",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.5",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "dev": true,
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.5",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-loader": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
+      "integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "1.0.0",
+        "loader-utils": "1.1.0",
+        "mkdirp": "0.5.1"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.3",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.5",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "dev": true
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "dev": true
+        }
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "dev": true
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.5",
+        "to-fast-properties": "1.0.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "dev": true
+        }
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -318,6 +544,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+      "dev": true
+    },
+    "big.js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
       "dev": true
     },
     "bl": {
@@ -645,6 +877,12 @@
         "graceful-readlink": "1.0.1"
       }
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -700,10 +938,22 @@
         }
       }
     },
+    "convert-source-map": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+      "dev": true
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
       "dev": true
     },
     "core-util-is": {
@@ -812,6 +1062,15 @@
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -849,6 +1108,12 @@
         "url-join": "2.0.5"
       }
     },
+    "emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "dev": true
+    },
     "end-of-stream": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
@@ -868,6 +1133,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "event-stream": {
@@ -1145,11 +1416,31 @@
         }
       }
     },
+    "find-cache-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+      "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+      "dev": true,
+      "requires": {
+        "commondir": "1.0.1",
+        "make-dir": "1.2.0",
+        "pkg-dir": "2.0.0"
+      }
+    },
     "find-index": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
       "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
       "dev": true
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "requires": {
+        "locate-path": "2.0.0"
+      }
     },
     "findup-sync": {
       "version": "2.0.0",
@@ -1396,6 +1687,12 @@
         "is-windows": "1.0.2",
         "which": "1.3.0"
       }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
     },
     "globule": {
       "version": "0.1.0",
@@ -1667,6 +1964,16 @@
       "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
       "dev": true
     },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
     "homedir-polyfill": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
@@ -1747,6 +2054,15 @@
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
+    },
     "is-absolute": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
@@ -1809,6 +2125,15 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-glob": {
       "version": "3.1.0",
@@ -1971,12 +2296,24 @@
       "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
       "dev": true
     },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
+    },
+    "jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -1994,6 +2331,12 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
     "jsonfile": {
@@ -2090,6 +2433,27 @@
       "resolved": "https://registry.npmjs.org/linerstream/-/linerstream-0.1.4.tgz",
       "integrity": "sha1-Xee/afqisPnYXoMyCZtw5BmoRdU=",
       "dev": true
+    },
+    "loader-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+      "dev": true,
+      "requires": {
+        "big.js": "3.2.0",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      }
     },
     "lodash": {
       "version": "1.0.2",
@@ -2222,11 +2586,29 @@
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
     "lru-cache": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
+    },
+    "make-dir": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+      "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+      "dev": true,
+      "requires": {
+        "pify": "3.0.0"
+      }
     },
     "make-iterator": {
       "version": "1.0.0",
@@ -2447,6 +2829,12 @@
       "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
       "dev": true
     },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -2629,6 +3017,30 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "p-limit": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.2.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
     "parse-filepath": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
@@ -2650,6 +3062,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
     "path-is-absolute": {
@@ -2799,6 +3217,12 @@
         "temp": "0.8.3"
       }
     },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
+    },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
@@ -2812,6 +3236,15 @@
       "dev": true,
       "requires": {
         "pinkie": "2.0.4"
+      }
+    },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0"
       }
     },
     "plugin-error": {
@@ -2917,6 +3350,12 @@
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -2962,6 +3401,12 @@
         "resolve": "1.5.0"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -2983,6 +3428,15 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
     },
     "replace-ext": {
       "version": "0.0.1",
@@ -3345,6 +3799,12 @@
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -3515,6 +3975,23 @@
         "resolve-url": "0.2.1",
         "source-map-url": "0.4.0",
         "urix": "0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "source-map-url": {
@@ -3780,6 +4257,12 @@
       "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
       "dev": true
     },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
+    },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -3830,6 +4313,12 @@
       "requires": {
         "punycode": "1.4.1"
       }
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2759,9 +2759,9 @@
       "dev": true
     },
     "monaco-editor-core": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.11.6.tgz",
-      "integrity": "sha512-WGJnnmtSY7qRYLRBOL23+pdQR6flUNKPAkREscc/ctiNRJHCqo0jFiSvuqh4VMfoVGkyprGCEjkBc+8/7nQuEA==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.11.7.tgz",
+      "integrity": "sha512-dWg+HmIAIl0LPSeyzN6CAtM//k9isMOrVsbg6ffwWOT7V8z7tDG50KW7F22i4N4vPu+KQdGF9BY/Ui0EFFRUkw==",
       "dev": true
     },
     "monaco-html": {

--- a/package.json
+++ b/package.json
@@ -17,11 +17,14 @@
     "url": "https://github.com/Microsoft/monaco-editor"
   },
   "devDependencies": {
+    "babel-core": "6.26.0",
+    "babel-loader": "7.1.4",
     "clean-css": "^3.4.20",
     "event-stream": "^3.3.2",
     "gulp": "^3.9.1",
     "gulp-typedoc": "^2.0.0",
     "http-server": "^0.11.1",
+    "loader-utils": "1.1.0",
     "monaco-css": "2.0.1",
     "monaco-editor-core": "0.11.6",
     "monaco-html": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "http-server": "^0.11.1",
     "loader-utils": "1.1.0",
     "monaco-css": "2.0.1",
-    "monaco-editor-core": "0.11.6",
+    "monaco-editor-core": "^0.11.7",
     "monaco-html": "2.0.2",
     "monaco-json": "2.0.1",
     "monaco-languages": "1.0.4",

--- a/webpack/features.js
+++ b/webpack/features.js
@@ -15,11 +15,7 @@ module.exports = {
     entry: 'vs/editor/contrib/clipboard/clipboard',
     worker: undefined,
   },
-  codeEditorWidget: {
-    entry: 'vs/editor/browser/widget/codeEditorWidget',
-    worker: undefined,
-  },
-  codelensController: {
+  codelens: {
     entry: 'vs/editor/contrib/codelens/codelensController',
     worker: undefined,
   },
@@ -43,19 +39,11 @@ module.exports = {
     entry: 'vs/editor/contrib/cursorUndo/cursorUndo',
     worker: undefined,
   },
-  diffEditorWidget: {
-    entry: 'vs/editor/browser/widget/diffEditorWidget',
-    worker: undefined,
-  },
-  diffNavigator: {
-    entry: 'vs/editor/browser/widget/diffNavigator',
-    worker: undefined,
-  },
   dnd: {
     entry: 'vs/editor/contrib/dnd/dnd',
     worker: undefined,
   },
-  findController: {
+  find: {
     entry: 'vs/editor/contrib/find/findController',
     worker: undefined,
   },
@@ -63,15 +51,15 @@ module.exports = {
     entry: 'vs/editor/contrib/folding/folding',
     worker: undefined,
   },
-  formatActions: {
+  format: {
     entry: 'vs/editor/contrib/format/formatActions',
     worker: undefined,
   },
-  goToDeclarationCommands: {
+  gotoDeclarationCommands: {
     entry: 'vs/editor/contrib/goToDeclaration/goToDeclarationCommands',
     worker: undefined,
   },
-  goToDeclarationMouse: {
+  gotoDeclarationMouse: {
     entry: 'vs/editor/contrib/goToDeclaration/goToDeclarationMouse',
     worker: undefined,
   },
@@ -139,11 +127,11 @@ module.exports = {
     entry: 'vs/editor/contrib/smartSelect/smartSelect',
     worker: undefined,
   },
-  snippetController2: {
+  snippets: {
     entry: 'vs/editor/contrib/snippet/snippetController2',
     worker: undefined,
   },
-  suggestController: {
+  suggest: {
     entry: 'vs/editor/contrib/suggest/suggestController',
     worker: undefined,
   },

--- a/webpack/features.js
+++ b/webpack/features.js
@@ -1,0 +1,170 @@
+module.exports = {
+  accessibilityHelp: {
+    entry: 'vs/editor/standalone/browser/accessibilityHelp/accessibilityHelp',
+    worker: undefined,
+  },
+  bracketMatching: {
+    entry: 'vs/editor/contrib/bracketMatching/bracketMatching',
+    worker: undefined,
+  },
+  caretOperations: {
+    entry: 'vs/editor/contrib/caretOperations/caretOperations',
+    worker: undefined,
+  },
+  clipboard: {
+    entry: 'vs/editor/contrib/clipboard/clipboard',
+    worker: undefined,
+  },
+  codeEditorWidget: {
+    entry: 'vs/editor/browser/widget/codeEditorWidget',
+    worker: undefined,
+  },
+  codelensController: {
+    entry: 'vs/editor/contrib/codelens/codelensController',
+    worker: undefined,
+  },
+  colorDetector: {
+    entry: 'vs/editor/contrib/colorPicker/colorDetector',
+    worker: undefined,
+  },
+  comment: {
+    entry: 'vs/editor/contrib/comment/comment',
+    worker: undefined,
+  },
+  contextmenu: {
+    entry: 'vs/editor/contrib/contextmenu/contextmenu',
+    worker: undefined,
+  },
+  coreCommands: {
+    entry: 'vs/editor/browser/controller/coreCommands',
+    worker: undefined,
+  },
+  cursorUndo: {
+    entry: 'vs/editor/contrib/cursorUndo/cursorUndo',
+    worker: undefined,
+  },
+  diffEditorWidget: {
+    entry: 'vs/editor/browser/widget/diffEditorWidget',
+    worker: undefined,
+  },
+  diffNavigator: {
+    entry: 'vs/editor/browser/widget/diffNavigator',
+    worker: undefined,
+  },
+  dnd: {
+    entry: 'vs/editor/contrib/dnd/dnd',
+    worker: undefined,
+  },
+  findController: {
+    entry: 'vs/editor/contrib/find/findController',
+    worker: undefined,
+  },
+  folding: {
+    entry: 'vs/editor/contrib/folding/folding',
+    worker: undefined,
+  },
+  formatActions: {
+    entry: 'vs/editor/contrib/format/formatActions',
+    worker: undefined,
+  },
+  goToDeclarationCommands: {
+    entry: 'vs/editor/contrib/goToDeclaration/goToDeclarationCommands',
+    worker: undefined,
+  },
+  goToDeclarationMouse: {
+    entry: 'vs/editor/contrib/goToDeclaration/goToDeclarationMouse',
+    worker: undefined,
+  },
+  gotoError: {
+    entry: 'vs/editor/contrib/gotoError/gotoError',
+    worker: undefined,
+  },
+  gotoLine: {
+    entry: 'vs/editor/standalone/browser/quickOpen/gotoLine',
+    worker: undefined,
+  },
+  hover: {
+    entry: 'vs/editor/contrib/hover/hover',
+    worker: undefined,
+  },
+  inPlaceReplace: {
+    entry: 'vs/editor/contrib/inPlaceReplace/inPlaceReplace',
+    worker: undefined,
+  },
+  inspectTokens: {
+    entry: 'vs/editor/standalone/browser/inspectTokens/inspectTokens',
+    worker: undefined,
+  },
+  iPadShowKeyboard: {
+    entry: 'vs/editor/standalone/browser/iPadShowKeyboard/iPadShowKeyboard',
+    worker: undefined,
+  },
+  linesOperations: {
+    entry: 'vs/editor/contrib/linesOperations/linesOperations',
+    worker: undefined,
+  },
+  links: {
+    entry: 'vs/editor/contrib/links/links',
+    worker: undefined,
+  },
+  multicursor: {
+    entry: 'vs/editor/contrib/multicursor/multicursor',
+    worker: undefined,
+  },
+  parameterHints: {
+    entry: 'vs/editor/contrib/parameterHints/parameterHints',
+    worker: undefined,
+  },
+  quickCommand: {
+    entry: 'vs/editor/standalone/browser/quickOpen/quickCommand',
+    worker: undefined,
+  },
+  quickFixCommands: {
+    entry: 'vs/editor/contrib/quickFix/quickFixCommands',
+    worker: undefined,
+  },
+  quickOutline: {
+    entry: 'vs/editor/standalone/browser/quickOpen/quickOutline',
+    worker: undefined,
+  },
+  referenceSearch: {
+    entry: 'vs/editor/contrib/referenceSearch/referenceSearch',
+    worker: undefined,
+  },
+  rename: {
+    entry: 'vs/editor/contrib/rename/rename',
+    worker: undefined,
+  },
+  smartSelect: {
+    entry: 'vs/editor/contrib/smartSelect/smartSelect',
+    worker: undefined,
+  },
+  snippetController2: {
+    entry: 'vs/editor/contrib/snippet/snippetController2',
+    worker: undefined,
+  },
+  suggestController: {
+    entry: 'vs/editor/contrib/suggest/suggestController',
+    worker: undefined,
+  },
+  toggleHighContrast: {
+    entry: 'vs/editor/standalone/browser/toggleHighContrast/toggleHighContrast',
+    worker: undefined,
+  },
+  toggleTabFocusMode: {
+    entry: 'vs/editor/contrib/toggleTabFocusMode/toggleTabFocusMode',
+    worker: undefined,
+  },
+  transpose: {
+    entry: 'vs/editor/contrib/caretOperations/transpose',
+    worker: undefined,
+  },
+  wordHighlighter: {
+    entry: 'vs/editor/contrib/wordHighlighter/wordHighlighter',
+    worker: undefined,
+  },
+  wordOperations: {
+    entry: 'vs/editor/contrib/wordOperations/wordOperations',
+    worker: undefined,
+  },
+};

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -1,0 +1,210 @@
+const path = require('path');
+const AddWorkerEntryPointPlugin = require('./plugins/AddWorkerEntryPointPlugin');
+const INCLUDE_LOADER_PATH = require.resolve('./loaders/include');
+
+const IGNORED_IMPORTS = {
+  [resolveMonacoPath('vs/language/typescript/lib/typescriptServices')]: [
+    'fs',
+    'path',
+    'os',
+    'crypto',
+    'source-map-support',
+  ],
+};
+const MONACO_EDITOR_API_PATHS = [
+  resolveMonacoPath('vs/editor/editor.main'),
+  resolveMonacoPath('vs/editor/editor.api')
+];
+const WORKER_LOADER_PATH = resolveMonacoPath('vs/editor/common/services/editorSimpleWorker');
+const EDITOR_MODULE = {
+  label: 'editorWorkerService',
+  entry: undefined,
+  worker: {
+    id: 'vs/editor/editor',
+    entry: 'vs/editor/editor.worker',
+    output: 'editor.worker.js',
+    fallback: undefined
+  },
+  alias: undefined,
+};
+const LANGUAGES = require('./languages');
+const FEATURES = require('./features');
+
+function resolveMonacoPath(filePath) {
+  return require.resolve(path.join('../esm', filePath));
+}
+
+const languagesById = fromPairs(
+  flatMap(toPairs(LANGUAGES), ([id, language]) =>
+    [id, ...(language.alias || [])].map((label) => [label, { label, ...language }])
+  )
+);
+const featuresById = mapValues(FEATURES, (feature, key) => ({ label: key, ...feature }))
+
+class MonacoWebpackPlugin {
+  constructor(webpack, options = {}) {
+    const languages = options.languages || Object.keys(languagesById);
+    const features = options.features || Object.keys(featuresById);
+    const output = options.output || '';
+    this.webpack = webpack;
+    this.options = {
+      languages: languages.map((id) => languagesById[id]).filter(Boolean),
+      features: features.map(id => featuresById[id]).filter(Boolean),
+      output,
+    };
+  }
+
+  apply(compiler) {
+    const webpack = this.webpack;
+    const { languages, features, output } = this.options;
+    const publicPath = getPublicPath(compiler);
+    const modules = [EDITOR_MODULE, ...languages, ...features];
+    const workers = modules.map(
+      ({ label, alias, worker }) => worker && ({ label, alias, ...worker })
+    ).filter(Boolean);
+    const rules = createLoaderRules(languages, features, workers, publicPath);
+    const plugins = createPlugins(webpack, workers, output);
+    addCompilerRules(compiler, rules);
+    addCompilerPlugins(compiler, plugins);
+  }
+}
+
+function addCompilerRules(compiler, rules) {
+  const compilerOptions = compiler.options;
+  const moduleOptions = compilerOptions.module || (compilerOptions.module = {});
+  const existingRules = moduleOptions.rules || (moduleOptions.rules = []);
+  existingRules.push(...rules);
+}
+
+function addCompilerPlugins(compiler, plugins) {
+  plugins.forEach((plugin) => plugin.apply(compiler));
+}
+
+function getPublicPath(compiler) {
+  return compiler.options.output && compiler.options.output.publicPath || '';
+}
+
+function stripTrailingSlash(string) {
+  return string.replace(/\/$/, '');
+}
+
+function createLoaderRules(languages, features, workers, publicPath) {
+  if (!languages.length && !features.length) { return []; }
+  const languagePaths = languages.map(({ entry }) => entry).filter(Boolean);
+  const featurePaths = features.map(({ entry }) => entry).filter(Boolean);
+  const workerPaths = workers.reduce((acc, { label, output }) => Object.assign(acc, {
+    [label]: `${publicPath ? `${stripTrailingSlash(publicPath)}/` : ''}${output}`,
+  }), {});
+  const globals = {
+    'MonacoEnvironment': `((paths) => ({ getWorkerUrl: (moduleId, label) => paths[label] }))(${
+      JSON.stringify(workerPaths, null, 2)
+    })`,
+  };
+  return [
+    {
+      test: MONACO_EDITOR_API_PATHS,
+      use: [
+        {
+          loader: INCLUDE_LOADER_PATH,
+          options: {
+            globals,
+            pre: featurePaths.map((importPath) => resolveMonacoPath(importPath)),
+            post: languagePaths.map((importPath) => resolveMonacoPath(importPath)),
+          },
+        },
+      ],
+    },
+    // HACK: This loader can be removed if the self.require() call in editorSimpleWorker.ts is
+    // replaced with a global require() call
+    {
+      test: WORKER_LOADER_PATH,
+      use: [
+        {
+          loader: require.resolve('babel-loader'),
+          options: {
+            plugins: [
+              replaceSelfRequireWithGlobalRequire(),
+            ],
+          },
+        },
+      ],
+    },
+  ];
+}
+
+function createPlugins(webpack, workers, outputPath) {
+  const workerFallbacks = workers.reduce((acc, { id, fallback }) => (fallback ? Object.assign(acc, {
+    [id]: resolveMonacoPath(fallback)
+  }) : acc), {});
+  return [
+    ...Object.keys(IGNORED_IMPORTS).map((id) =>
+      createIgnoreImportsPlugin(webpack, id, IGNORED_IMPORTS[id])
+    ),
+    ...workers.map(({ id, entry, output }) =>
+      createEntryPointPlugin(webpack, id, resolveMonacoPath(entry), path.join(outputPath, output))
+    ),
+    ...(workerFallbacks ? [createContextPlugin(webpack, WORKER_LOADER_PATH, workerFallbacks)] : []),
+  ];
+}
+
+function createContextPlugin(webpack, filePath, contextPaths) {
+  return new webpack.ContextReplacementPlugin(
+    new RegExp(`^${path.dirname(filePath)}$`),
+    '',
+    contextPaths
+  )
+}
+
+function createIgnoreImportsPlugin(webpack, targetPath, ignoredModules) {
+  return new webpack.IgnorePlugin(
+    new RegExp(`^(${ignoredModules.map((id) => `(${id})`).join('|')})$`),
+    new RegExp(`^${path.dirname(targetPath)}$`)
+  );
+}
+
+function createEntryPointPlugin(webpack, id, entry, output) {
+  return new AddWorkerEntryPointPlugin(webpack, { id, entry, output });
+}
+
+function replaceSelfRequireWithGlobalRequire() {
+	return (babel) => {
+		const { types: t } = babel;
+		return {
+			visitor: {
+				CallExpression(path) {
+					const { node } = path;
+					const isSelfRequireExpression = (
+						t.isMemberExpression(node.callee)
+						&& t.isIdentifier(node.callee.object, { name: 'self' })
+						&& t.isIdentifier(node.callee.property, { name: 'require' })
+						&& t.isArrayExpression(node.arguments[0])
+						&& t.isFunction(node.arguments[1])
+					);
+					if (!isSelfRequireExpression) { return; }
+					path.get('callee').replaceWith(t.identifier('require'));
+				}
+			},
+		};
+	};
+}
+
+function flatMap(items, iteratee) {
+  return items.map(iteratee).reduce((acc, item) => [...acc, ...item], []);
+}
+
+function toPairs(object) {
+  return Object.keys(object).map((key) => [key, object[key]]);
+}
+
+function fromPairs(values) {
+  return values.reduce((acc, [key, value]) => Object.assign(acc, { [key]: value }), {});
+}
+
+function mapValues(object, iteratee) {
+  return Object.keys(object).reduce(
+    (acc, key) => Object.assign(acc, { [key]: iteratee(object[key], key) }),
+    {}
+  );
+}
+
+module.exports = MonacoWebpackPlugin;

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -114,21 +114,6 @@ function createLoaderRules(languages, features, workers, publicPath) {
         },
       ],
     },
-    // HACK: This loader can be removed if the self.require() call in editorSimpleWorker.ts is
-    // replaced with a global require() call
-    {
-      test: WORKER_LOADER_PATH,
-      use: [
-        {
-          loader: require.resolve('babel-loader'),
-          options: {
-            plugins: [
-              replaceSelfRequireWithGlobalRequire(),
-            ],
-          },
-        },
-      ],
-    },
   ];
 }
 
@@ -164,28 +149,6 @@ function createIgnoreImportsPlugin(webpack, targetPath, ignoredModules) {
 
 function createEntryPointPlugin(webpack, id, entry, output) {
   return new AddWorkerEntryPointPlugin(webpack, { id, entry, output });
-}
-
-function replaceSelfRequireWithGlobalRequire() {
-	return (babel) => {
-		const { types: t } = babel;
-		return {
-			visitor: {
-				CallExpression(path) {
-					const { node } = path;
-					const isSelfRequireExpression = (
-						t.isMemberExpression(node.callee)
-						&& t.isIdentifier(node.callee.object, { name: 'self' })
-						&& t.isIdentifier(node.callee.property, { name: 'require' })
-						&& t.isArrayExpression(node.arguments[0])
-						&& t.isFunction(node.arguments[1])
-					);
-					if (!isSelfRequireExpression) { return; }
-					path.get('callee').replaceWith(t.identifier('require'));
-				}
-			},
-		};
-	};
 }
 
 function flatMap(items, iteratee) {

--- a/webpack/languages.js
+++ b/webpack/languages.js
@@ -1,0 +1,222 @@
+module.exports = {
+  bat: {
+    entry: 'vs/basic-languages/bat/bat.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  coffee: {
+    entry: 'vs/basic-languages/coffee/coffee.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  cpp: {
+    entry: 'vs/basic-languages/cpp/cpp.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  csharp: {
+    entry: 'vs/basic-languages/csharp/csharp.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  csp: {
+    entry: 'vs/basic-languages/csp/csp.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  css: {
+    entry: 'vs/language/css/monaco.contribution',
+    worker: {
+      id: 'vs/language/css/cssWorker',
+      entry: 'vs/language/css/css.worker',
+      output: 'css.worker.js',
+      fallback: 'vs/language/css/cssWorker',
+    },
+    alias: undefined,
+  },
+  dockerfile: {
+    entry: 'vs/basic-languages/dockerfile/dockerfile.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  fsharp: {
+    entry: 'vs/basic-languages/fsharp/fsharp.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  go: {
+    entry: 'vs/basic-languages/go/go.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  handlebars: {
+    entry: 'vs/basic-languages/handlebars/handlebars.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  html: {
+    entry: 'vs/language/html/monaco.contribution',
+    worker: {
+      id: 'vs/language/html/htmlWorker',
+      entry: 'vs/language/html/html.worker',
+      output: 'html.worker.js',
+      fallback: 'vs/language/html/htmlWorker',
+    },
+    alias: undefined,
+  },
+  ini: {
+    entry: 'vs/basic-languages/ini/ini.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  java: {
+    entry: 'vs/basic-languages/java/java.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  json: {
+    entry: 'vs/language/json/monaco.contribution',
+    worker: {
+      id: 'vs/language/json/jsonWorker',
+      entry: 'vs/language/json/json.worker',
+      output: 'json.worker.js',
+      fallback: 'vs/language/json/jsonWorker',
+    },
+    alias: undefined,
+  },
+  less: {
+    entry: 'vs/basic-languages/less/less.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  lua: {
+    entry: 'vs/basic-languages/lua/lua.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  markdown: {
+    entry: 'vs/basic-languages/markdown/markdown.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  msdax: {
+    entry: 'vs/basic-languages/msdax/msdax.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  mysql: {
+    entry: 'vs/basic-languages/mysql/mysql.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  objective: {
+    entry: 'vs/basic-languages/objective-c/objective-c.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  pgsql: {
+    entry: 'vs/basic-languages/pgsql/pgsql.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  php: {
+    entry: 'vs/basic-languages/php/php.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  postiats: {
+    entry: 'vs/basic-languages/postiats/postiats.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  powershell: {
+    entry: 'vs/basic-languages/powershell/powershell.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  pug: {
+    entry: 'vs/basic-languages/pug/pug.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  python: {
+    entry: 'vs/basic-languages/python/python.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  r: {
+    entry: 'vs/basic-languages/r/r.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  razor: {
+    entry: 'vs/basic-languages/razor/razor.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  redis: {
+    entry: 'vs/basic-languages/redis/redis.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  redshift: {
+    entry: 'vs/basic-languages/redshift/redshift.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  ruby: {
+    entry: 'vs/basic-languages/ruby/ruby.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  sb: {
+    entry: 'vs/basic-languages/sb/sb.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  scss: {
+    entry: 'vs/basic-languages/scss/scss.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  solidity: {
+    entry: 'vs/basic-languages/solidity/solidity.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  sql: {
+    entry: 'vs/basic-languages/sql/sql.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  swift: {
+    entry: 'vs/basic-languages/swift/swift.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  typescript: {
+    entry: 'vs/language/typescript/monaco.contribution',
+    worker: {
+      id: 'vs/language/typescript/tsWorker',
+      entry: 'vs/language/typescript/ts.worker',
+      output: 'typescript.worker.js',
+      fallback: 'vs/language/typescript/tsWorker',
+    },
+    alias: ['javascript'],
+  },
+  vb: {
+    entry: 'vs/basic-languages/vb/vb.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  xml: {
+    entry: 'vs/basic-languages/xml/xml.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+  yaml: {
+    entry: 'vs/basic-languages/yaml/yaml.contribution',
+    worker: undefined,
+    alias: undefined,
+  },
+};

--- a/webpack/loaders/include.js
+++ b/webpack/loaders/include.js
@@ -1,0 +1,20 @@
+const loaderUtils = require('loader-utils');
+
+module.exports.pitch = function pitch(remainingRequest) {
+  const { globals = undefined, pre = [], post = [] } = loaderUtils.getOptions(this) || {};
+
+  // HACK: NamedModulesPlugin overwrites existing modules when requesting the same module via
+  // different loaders, so we need to circumvent this by appending a suffix to make the name unique
+  // See https://github.com/webpack/webpack/issues/4613#issuecomment-325178346 for details
+  this._module.userRequest = `include-loader!${this._module.userRequest}`;
+
+  return [
+    ...(globals
+      ? Object.keys(globals).map((key) => `self[${JSON.stringify(key)}] = ${globals[key]};`)
+      : []
+    ),
+    ...pre.map((include) => `require(${loaderUtils.stringifyRequest(this, include)});`),
+    `module.exports = require(${loaderUtils.stringifyRequest(this, `!!${remainingRequest}`)});`,
+    ...post.map((include) => `require(${loaderUtils.stringifyRequest(this, include)});`),
+  ].join('\n');
+};

--- a/webpack/plugins/AddWorkerEntryPointPlugin.js
+++ b/webpack/plugins/AddWorkerEntryPointPlugin.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 class AddWorkerEntryPointPlugin {
   constructor(webpack, { id, entry, output }) {
     this.webpack = webpack;
@@ -11,6 +13,7 @@ class AddWorkerEntryPointPlugin {
       const outputOptions = {
         filename: output,
         publicPath: compilation.outputOptions.publicPath,
+        chunkFilename: `${path.basename(output)}.[id].js`,
         // HACK: globalObject is necessary to fix https://github.com/webpack/webpack/issues/6642
         globalObject: 'this',
       };

--- a/webpack/plugins/AddWorkerEntryPointPlugin.js
+++ b/webpack/plugins/AddWorkerEntryPointPlugin.js
@@ -1,0 +1,27 @@
+class AddWorkerEntryPointPlugin {
+  constructor(webpack, { id, entry, output }) {
+    this.webpack = webpack;
+    this.options = { id, entry, output };
+  }
+
+  apply(compiler) {
+    const webpack = this.webpack;
+    const { id, entry, output } = this.options;
+    compiler.plugin('make', (compilation, callback) => {
+      const outputOptions = {
+        filename: output,
+        publicPath: compilation.outputOptions.publicPath,
+        // HACK: globalObject is necessary to fix https://github.com/webpack/webpack/issues/6642
+        globalObject: 'this',
+      };
+      const childCompiler = compilation.createChildCompiler(id, outputOptions, [
+        new webpack.webworker.WebWorkerTemplatePlugin(),
+        new webpack.LoaderTargetPlugin('webworker'),
+        new webpack.SingleEntryPlugin(this.context, entry, 'main'),
+      ]);
+      childCompiler.runAsChild(callback);
+    });
+  }
+}
+
+module.exports = AddWorkerEntryPointPlugin;

--- a/webpack/plugins/AddWorkerEntryPointPlugin.js
+++ b/webpack/plugins/AddWorkerEntryPointPlugin.js
@@ -1,5 +1,3 @@
-const path = require('path');
-
 class AddWorkerEntryPointPlugin {
   constructor(webpack, { id, entry, output }) {
     this.webpack = webpack;
@@ -13,7 +11,6 @@ class AddWorkerEntryPointPlugin {
       const outputOptions = {
         filename: output,
         publicPath: compilation.outputOptions.publicPath,
-        chunkFilename: `${path.basename(output)}.[id].js`,
         // HACK: globalObject is necessary to fix https://github.com/webpack/webpack/issues/6642
         globalObject: 'this',
       };


### PR DESCRIPTION
The recent ESM build works brilliantly, and it's really exciting to finally have the monaco editor as a first-class citizen of the webpack ecosystem.

Unfortunately, the user needs to make several non-intuitive additions to their webpack config and source code before they can use it:

1. Add additional `entry` points for each of the required worker scrips
2. Manually create a `MonacoEnvironment` that references the output paths provided for these entry points
3. Add a `webpack.IgnorePlugin()` that references an internal file within `monaco-editor` package
4. (optional) Manually `import` specific feature modules from deep within the `monaco-editor` package if the user wants to customise the editor build

None of these steps is obvious without deep knowledge of how `monaco-editor` code is structured internally, increasing the potential for various unexpected gotchas along the way.

This PR demonstrates a potential technique to simplify importing the Monaco Editor into a webpack project by exporting a webpack plugin from the `monaco-editor` package. It allows the user to import the editor with just a single addition to their webpack config, and automatically sets up the global environment, compiles additional worker files etc:

**webpack.config.js:**
```javascript
const webpack = require('webpack');
const MonacoWebpackPlugin = require('monaco-editor/webpack');

module.exports = {
  entry: './index.js',
  output: {
    path: path.resolve(__dirname, 'dist'),
    filename: 'app.js'
  },
  plugins: [
    new MonacoWebpackPlugin(webpack)
  ]
};
```

**index.js:**
```javascript
import * as monaco from 'monaco-editor';

monaco.editor.create(document.getElementById('container'), {
	value: 'console.log("Hello, world")',
	language: 'javascript'
});
```

For a more custom configuration, the user can specify which languages/features they want, as well as the worker scripts output directory:

**webpack.config.js:**
```javascript
const webpack = require('webpack');
const MonacoWebpackPlugin = require('monaco-editor/webpack');

module.exports = {
  entry: './index.js',
  output: {
    path: path.resolve(__dirname, 'dist'),
    filename: 'app.js'
  },
  plugins: [
    new MonacoWebpackPlugin(webpack, {
      languages: ['python'],
      features: ['coreCommands', 'findController'],
      output: './workers/monaco'
    })
  ]
};
```

**index.js:**
```javascript
import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';

monaco.editor.create(document.getElementById('container'), {
	value: 'print("Hello, world")',
	language: 'python'
});
```

Points for improvement/discussion:

- The `monaco-editor` vs `monaco-editor/esm/vs/editor/editor.api`distinction is a bit confusing: if the primary target is webpack users then you could just set the main `monaco-editor` export to the `editor.api.js` version (rather than the current `editor.main.js` version) and let the plugin handle adding all the features. If you prefer to keep `monaco-editor` exporting the whole batteries-included editor, you could at least simplify the paths into say `monaco-editor` vs `monaco-editor/custom` or something.
- The plugin options are currently not validated (webpack and its libraries typically use [ajv](https://www.npmjs.com/package/ajv) for options schema validation)
- The features could better named in `webpack/features.js` – for the time being I just took the basename of each file but a lot of them include `Controller` or whatever, and aren't great names for API options
- I haven't updated the readme to include plugin usage instructions
- Worker fallbacks are included as normal webpack imports – under default webpack settings this will generate separate files that are loaded in on-demand via JSONP, which is probably fine, however maybe `import()` expressions would be better from a code-splitting perspective
- The plugin uses various of the inbuilt webpack plugins, so it needs a reference to the webpack library. I didn't want to introduce an additional `"webpack"` dependency to `monaco-editor`, so I've gone with passing a `webpack` instance into the plugin constructor instead. While this is arguably more flexible, it is susceptible to breaking changes in the webpack library. This could be worked around by adding webpack as a peerDependency of the `monaco-editor` package, or by extracting the plugin out into its own separate package entirely, which would have its own peerDependency on `"webpack"`
- There's currently a babel transform that replaces the `self.require()` call in `editorSimpleWorker.js` with a global `require()` call. The babel transform could be removed if the vscode source were changed.

This doesn't impact how the package currently functions of course: the plugin is an optional add-on whose main task is to autogenerate webpack configuration rather than the user doing it manually. This means that if e.g. the user doesn't use webpack, they can just not use the plugin and they can continue as normal.

I realise this is quite a big addition, so if you guys want to re-implement this yourselves or just trash it or whatever that's fine, I just wanted to propose it as a potential avenue to explore. I'm eager to help make this library as easy as possible for users to consume in their projects, and I feel like something like this would be the missing piece of the puzzle. Let me know if there's anything I can do to help!