### PR TITLE
Add folding provider sample to the playground

### DIFF
--- a/test/playground.generated/extending-language-services-folding-provider-example.html
+++ b/test/playground.generated/extending-language-services-folding-provider-example.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<!-- THIS IS A GENERATED FILE VIA gulp generate-test-samples -->
+<html>
+<head>
+	<base href="..">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+</head>
+<body>
+<style>
+/*----------------------------------------SAMPLE CSS START*/
+
+
+
+/*----------------------------------------SAMPLE CSS END*/
+</style>
+<a class="loading-opts" href="playground.generated/index.html">[&lt;&lt; BACK]</a> <br/>
+THIS IS A GENERATED FILE VIA gulp generate-test-samples
+
+<div id="bar" style="margin-bottom: 6px;"></div>
+
+<div style="clear:both"></div>
+<div id="outer-container" style="width:800px;height:450px;border: 1px solid grey">
+<!-- ----------------------------------------SAMPLE HTML START-->
+
+<div id="container" style="height:100%;"></div>
+
+
+<!-- ----------------------------------------SAMPLE HTML END-->
+</div>
+<div style="clear:both"></div>
+
+<script src="../metadata.js"></script>
+<script src="dev-setup.js"></script>
+<script>
+loadEditor(function() {
+/*----------------------------------------SAMPLE JS START*/
+
+monaco.languages.register({
+    id: "foldLanguage"
+});
+
+var value =
+`1. Hit F1 to bring up the Command Palette
+2. Type 'fold'
+3. Choose 'Fold All Block Comments' or 'Fold All Regions'
+
+5. comment1
+6. comment1
+7. comment1
+
+9. unfoldable text
+10. unfoldable text
+11. unfoldable text
+
+13. comment2
+14. comment2
+15. comment2
+16. comment2
+17. comment2
+
+19. foldable text
+20. foldable text
+21. foldable text
+
+23. region1
+24. region1
+25. region1
+
+27. region2
+28. region2
+29. region2`
+
+monaco.editor.create(document.getElementById("container"), {
+    value: value,
+    language: "foldLanguage"
+});
+
+monaco.languages.registerFoldingRangeProvider("foldLanguage", {
+    provideFoldingRanges: function(model, context, token) {
+        return [
+            // comment1
+            {
+                start: 5,
+                end: 7,
+                kind: monaco.languages.FoldingRangeKind.Comment
+            },
+            // comment2
+            {
+                start: 13,
+                end: 17,
+                kind: monaco.languages.FoldingRangeKind.Comment
+            },
+            // foldable text
+            {
+                start: 19,
+                end: 21
+            },
+            // region1
+            {
+                start: 23,
+                end: 25,
+                kind: monaco.languages.FoldingRangeKind.Region
+            },
+            // region2
+            {
+                start: 27,
+                end: 29,
+                kind: monaco.languages.FoldingRangeKind.Region
+            }
+        ];
+    }
+});
+
+/*----------------------------------------SAMPLE CSS END*/
+});
+</script>
+</body>
+</html>

--- a/test/playground.generated/index.html
+++ b/test/playground.generated/index.html
@@ -30,6 +30,7 @@ THIS IS A GENERATED FILE VIA gulp generate-test-samples<br/><br/>
 <a class="loading-opts" href="playground.generated/extending-language-services-completion-provider-example.html">Extending Language Services &gt; Completion provider example</a><br/>
 <a class="loading-opts" href="playground.generated/extending-language-services-codelens-provider-example.html">Extending Language Services &gt; Codelens provider example</a><br/>
 <a class="loading-opts" href="playground.generated/extending-language-services-color-provider-example.html">Extending Language Services &gt; Color provider example</a><br/>
+<a class="loading-opts" href="playground.generated/extending-language-services-folding-provider-example.html">Extending Language Services &gt; Folding provider example</a><br/>
 <a class="loading-opts" href="playground.generated/extending-language-services-hover-provider-example.html">Extending Language Services &gt; Hover provider example</a><br/>
 <a class="loading-opts" href="playground.generated/extending-language-services-configure-javascript-defaults.html">Extending Language Services &gt; Configure JavaScript defaults</a><br/>
 <a class="loading-opts" href="playground.generated/extending-language-services-configure-json-defaults.html">Extending Language Services &gt; Configure JSON defaults</a>

--- a/website/playground/new-samples/all.js
+++ b/website/playground/new-samples/all.js
@@ -141,6 +141,12 @@ var PLAY_SAMPLES = [
 	},
 	{
 		chapter: "Extending Language Services",
+		name: "Folding provider example",
+		id: "extending-language-services-folding-provider-example",
+		path: "extending-language-services/folding-provider-example"
+	},
+	{
+		chapter: "Extending Language Services",
 		name: "Hover provider example",
 		id: "extending-language-services-hover-provider-example",
 		path: "extending-language-services/hover-provider-example"

--- a/website/playground/new-samples/extending-language-services/folding-provider-example/sample.html
+++ b/website/playground/new-samples/extending-language-services/folding-provider-example/sample.html
@@ -1,0 +1,1 @@
+<div id="container" style="height:100%;"></div>

--- a/website/playground/new-samples/extending-language-services/folding-provider-example/sample.js
+++ b/website/playground/new-samples/extending-language-services/folding-provider-example/sample.js
@@ -1,0 +1,75 @@
+monaco.languages.register({
+    id: "foldLanguage"
+});
+
+var value =
+`1. Hit F1 to bring up the Command Palette
+2. Type 'fold'
+3. Choose 'Fold All Block Comments' or 'Fold All Regions'
+
+5. comment1
+6. comment1
+7. comment1
+
+9. unfoldable text
+10. unfoldable text
+11. unfoldable text
+
+13. comment2
+14. comment2
+15. comment2
+16. comment2
+17. comment2
+
+19. foldable text
+20. foldable text
+21. foldable text
+
+23. region1
+24. region1
+25. region1
+
+27. region2
+28. region2
+29. region2`
+
+monaco.editor.create(document.getElementById("container"), {
+    value: value,
+    language: "foldLanguage"
+});
+
+monaco.languages.registerFoldingRangeProvider("foldLanguage", {
+    provideFoldingRanges: function(model, context, token) {
+        return [
+            // comment1
+            {
+                start: 5,
+                end: 7,
+                kind: monaco.languages.FoldingRangeKind.Comment
+            },
+            // comment2
+            {
+                start: 13,
+                end: 17,
+                kind: monaco.languages.FoldingRangeKind.Comment
+            },
+            // foldable text
+            {
+                start: 19,
+                end: 21
+            },
+            // region1
+            {
+                start: 23,
+                end: 25,
+                kind: monaco.languages.FoldingRangeKind.Region
+            },
+            // region2
+            {
+                start: 27,
+                end: 29,
+                kind: monaco.languages.FoldingRangeKind.Region
+            }
+        ];
+    }
+});


### PR DESCRIPTION
A new `monaco.languages.registerFoldingRangeProvider` API was added in 0.13.0 to allow people to create custom folding regions. I've created a small example that demonstrates how to use this API for the Monaco Playground.