### PR TITLE
Fix hash comment in xdot sample

### DIFF
--- a/website/monarch.html
+++ b/website/monarch.html
@@ -2989,7 +2989,7 @@ return {
       [/[ \t\r\n]+/, 'white'],
       [/\/\*/,       'comment', '@comment' ],
       [/\/\/.*$/,    'comment'],
-      [/#.$/,        'comment'],
+      [/#.*$/,       'comment'],
     ],
   },
 };


### PR DESCRIPTION
The xdot comment using hash does only include one following character. It should be like `//`, spanning to the end of the line.