### PR TITLE
fix small error in integration docs

### DIFF
--- a/docs/integrate-amd-cross.md
+++ b/docs/integrate-amd-cross.md
@@ -26,7 +26,7 @@ Assuming the HTML lives on `www.mydomain.com` and the editor is hosted on `www.m
     getWorkerUrl: function(workerId, label) {
       return `data:text/javascript;charset=utf-8,${encodeURIComponent(`
         self.MonacoEnvironment = {
-          baseUrl: 'http://www.mycdn.com/monaco-editor/min/vs'
+          baseUrl: 'http://www.mycdn.com/monaco-editor/min/'
         };
         importScripts('http://www.mycdn.com/monaco-editor/min/vs/base/worker/workerMain.js');`
       )}`;


### PR DESCRIPTION
A small mistake fixed. `baseUrl` should be the same as in the option 2 (read below in the same document) . If not it won't work and can give unnecessary pain to newcomers. Good work :) keep it up!