### PR TITLE
Fix playground sample option

### DIFF
--- a/test/playground.generated/interacting-with-the-editor-listening-to-mouse-events.html
+++ b/test/playground.generated/interacting-with-the-editor-listening-to-mouse-events.html
@@ -60,7 +60,7 @@ var editor = monaco.editor.create(document.getElementById("container"), {
 	value: jsCode,
 	language: "javascript",
 	glyphMargin: true,
-	nativeContextMenu: false
+	contextmenu: false
 });
 
 var decorations = editor.deltaDecorations([], [

--- a/website/playground/new-samples/interacting-with-the-editor/listening-to-mouse-events/sample.js
+++ b/website/playground/new-samples/interacting-with-the-editor/listening-to-mouse-events/sample.js
@@ -14,7 +14,7 @@ var editor = monaco.editor.create(document.getElementById("container"), {
 	value: jsCode,
 	language: "javascript",
 	glyphMargin: true,
-	nativeContextMenu: false
+	contextmenu: false
 });
 
 var decorations = editor.deltaDecorations([], [


### PR DESCRIPTION
The `nativeContextMenu` property did not work, so I changed it to the` contextmenu` property.