### PR TITLE
Aligned provideHover signature to actual implementation

### DIFF
--- a/monaco.d.ts
+++ b/monaco.d.ts
@@ -4723,7 +4723,7 @@ declare namespace monaco.languages {
          * position will be merged by the editor. A hover can have a range which defaults
          * to the word range at the position when omitted.
          */
-        provideHover(model: editor.ITextModel, position: Position, token: CancellationToken): Hover | Thenable<Hover>;
+        provideHover(model: editor.ITextModel, position: Position, token: CancellationToken): Hover | undefined | null | Thenable<Hover | undefined | null>;
     }
 
     /**


### PR DESCRIPTION
fixes https://github.com/Microsoft/monaco-editor/issues/1021

I checked the actual working in real code for this change but I have no idea how the build and/or tests in this project work so this change is only 85% safe from my point of view, sorry.