### PR TITLE
add dynamic brace matching to documentation

### DIFF
--- a/monaco.d.ts
+++ b/monaco.d.ts
@@ -5706,3 +5706,5 @@ declare namespace monaco.languages.html {
     export var handlebarDefaults: LanguageServiceDefaults;
     export var razorDefaults: LanguageServiceDefaults;
 }
+
+declare namespace monaco.languages.setLanguageConfiguration('myCustomLanguage', {brackets:[['(',')']]});


### PR DESCRIPTION
closes #107

I wasn't able to run the specs. I followed the contributing guide but when I try and run ```npm run monaco-editor-test``` in the ```vscode``` directory I get:
```Bash
> code-oss-dev@1.29.0 monaco-editor-test /Users/player1/Hoth/vscode
> mocha --only-monaco-editor


  error: unknown option `--only-monaco-editor'

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! code-oss-dev@1.29.0 monaco-editor-test: `mocha --only-monaco-editor`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the code-oss-dev@1.29.0 monaco-editor-test script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/player1/.npm/_logs/2018-10-11T11_56_24_644Z-debug.log
```