### PR TITLE
Add allowNonTsExtensions to CompilerOptions

### DIFF
--- a/monaco.d.ts
+++ b/monaco.d.ts
@@ -5451,6 +5451,7 @@ declare namespace monaco.languages.typescript {
     type CompilerOptionsValue = string | number | boolean | (string | number)[] | string[] | MapLike<string[]> | null | undefined;
     interface CompilerOptions {
         allowJs?: boolean;
+        allowNonTsExtensions?: boolean;
         allowSyntheticDefaultImports?: boolean;
         allowUnreachableCode?: boolean;
         allowUnusedLabels?: boolean;


### PR DESCRIPTION
I don't know why `allowNonTsExtensions` is missing from `CompilerOptions`.  This bit me recently as you _have_ to set `allowNonTsExtensions: true` when using in-memory models.  When running in compiled mode, this property got renamed as it was missing from `monaco.d.ts`

Note: I didn't add the newline at the end of the file.  I edited the file directly in github and its editor appears to have added it as part of saving my change.