### PR TITLE
Use enum instead of const enum: Type error: Ambient const enums are not allowed with --isolatedModules

### DIFF
--- a/monaco.d.ts
+++ b/monaco.d.ts
@@ -1987,7 +1987,7 @@ declare namespace monaco.editor {
      */
     export type IEditorViewState = ICodeEditorViewState | IDiffEditorViewState;
 
-    export const enum ScrollType {
+    export enum ScrollType {
         Smooth = 0,
         Immediate = 1
     }
@@ -3140,7 +3140,7 @@ declare namespace monaco.editor {
         readonly wordWrapBreakObtrusiveCharacters: string;
     }
 
-    export const enum RenderLineNumbersType {
+    export enum RenderLineNumbersType {
         Off = 0,
         On = 1,
         Relative = 2,


### PR DESCRIPTION
**Summary**
This PR fixes the following type error:

Type error: Ambient const enums are not allowed when the '--isolatedModules' flag is provided.  TS1209

references
* https://github.com/Microsoft/TypeScript/issues/20703
