### PR TITLE
Fix JavaScript RegExp range closing bracket

### DIFF
--- a/website/monarch.html
+++ b/website/monarch.html
@@ -772,7 +772,7 @@ return {
 			[/\^/, 'regexp.invalid'],
 			[/@regexpesc/, 'regexp.escape'],
 			[/[^\]]/, 'regexp'],
-			[/\]/, '@brackets.regexp.escape.control', '@pop'],
+			[/\]/, { token: 'regexp.escape.control', next: '@pop', bracket: '@close' }],
 		],
 
 		string_double: [


### PR DESCRIPTION
The Monarch tokenizer for JavaScript has a bug where the closing bracket for the RegExp range refers to a `brackets` attribute that does not exist. This bug causes the closing bracket to not be colored using the regexp style.