### PR TITLE
Fix lineDecoration example css error

### DIFF
--- a/website/playground/new-samples/interacting-with-the-editor/line-and-inline-decorations/sample.css
+++ b/website/playground/new-samples/interacting-with-the-editor/line-and-inline-decorations/sample.css
@@ -5,8 +5,9 @@
 	font-weight: bold;
 	font-style: oblique;
 }
+
 .myLineDecoration {
 	background: lightblue;
 	width: 5px !important;
-	left: 3px;
+	margin-left: 3px;
 }


### PR DESCRIPTION
'left' style will not work in linesDecorationsClassName, but 'margin-left' do