### PR TITLE
Fix C# sample code

### DIFF
--- a/website/index/samples/sample.csharp.txt
+++ b/website/index/samples/sample.csharp.txt
@@ -14,7 +14,7 @@ namespace VS
 			ProcessStartInfo si = new ProcessStartInfo();
 			float load= 3.2e02f;
 
-			si.FileName = @"tools\\node.exe";
+			si.FileName = "tools\\node.exe";
 			si.Arguments = "tools\\simpleserver.js";
 
 			Process.Start(si);


### PR DESCRIPTION
String literal does not need to be @-escaped.
Alternatively, one could remove one of the backslashes in the line.