### PR TITLE
Make range optional in CompletionItem definition

### DIFF
--- a/monaco.d.ts
+++ b/monaco.d.ts
@@ -4886,7 +4886,7 @@ declare namespace monaco.languages {
          * *Note:* The range must be a [single line](#Range.isSingleLine) and it must
          * [contain](#Range.contains) the position at which completion has been [requested](#CompletionItemProvider.provideCompletionItems).
          */
-        range: IRange;
+        range?: IRange;
         /**
          * An optional set of characters that when pressed while this completion is active will accept it first and
          * then type that character. *Note* that all commit characters should have `length=1` and that superfluous


### PR DESCRIPTION
This PR fixes the type error `Property 'range' is missing in type '{ label: string; kind: CompletionItemKind.Function; documentation: string; insertText: string; }' but required in type 'CompletionItem'.`

The range is not required. It is stated in the docstring that it 
`Defaults to a range from the start of the [current word](#TextDocument.getWordRangeAtPosition) to the current position.`

It is not included in the example code either:
https://microsoft.github.io/monaco-editor/playground.html#extending-language-services-completion-provider-example