### PR TITLE
Make token optional in ITokenThemeRule interface

### DIFF
--- a/monaco.d.ts
+++ b/monaco.d.ts
@@ -963,7 +963,7 @@ declare namespace monaco.editor {
     };
 
     export interface ITokenThemeRule {
-        token: string;
+        token?: string;
         foreground?: string;
         background?: string;
         fontStyle?: string;


### PR DESCRIPTION
Theme options should allow rules without token.

Example : 
```
    /// https://microsoft.github.io/monaco-editor/playground.html#customizing-the-appearence-exposed-colors
    monaco.editor.defineTheme('myTheme', {
        rules: [{ background: 'EDF9FA' }],
    });
```