### PR TITLE
Add CompletionItem with snippet support to the example

### DIFF
--- a/test/playground.generated/extending-language-services-completion-provider-example.html
+++ b/test/playground.generated/extending-language-services-completion-provider-example.html
@@ -57,6 +57,13 @@ function createDependencyProposals() {
             kind: monaco.languages.CompletionItemKind.Function,
             documentation: "Recursively mkdir, like <code>mkdir -p</code>",
             insertText: '"mkdirp": "*"'
+        },
+        {
+            label: '"my-third-party-library"',
+            kind: monaco.languages.CompletionItemKind.Function,
+            documentation: "Describe your library here",
+            insertText: '"${1:my-third-party-library}": "${2:1.2.3}"',
+            insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet
         }
     ];
 }

--- a/website/playground/new-samples/extending-language-services/completion-provider-example/sample.js
+++ b/website/playground/new-samples/extending-language-services/completion-provider-example/sample.js
@@ -19,6 +19,13 @@ function createDependencyProposals() {
             kind: monaco.languages.CompletionItemKind.Function,
             documentation: "Recursively mkdir, like <code>mkdir -p</code>",
             insertText: '"mkdirp": "*"'
+        },
+        {
+            label: '"my-third-party-library"',
+            kind: monaco.languages.CompletionItemKind.Function,
+            documentation: "Describe your library here",
+            insertText: '"${1:my-third-party-library}": "${2:1.2.3}"',
+            insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet
         }
     ];
 }


### PR DESCRIPTION
Many users are asking about snippet support in Monaco. Enhancing the example on in the playground with a snippet CompletionItem will help users learn about the feature more easily without having to dig through Stack Overflow and GitHub issues.