### PR TITLE
Playground: fix codelens provider example

### DIFF
--- a/website/playground/new-samples/extending-language-services/codelens-provider-example/sample.js
+++ b/website/playground/new-samples/extending-language-services/codelens-provider-example/sample.js
@@ -11,7 +11,7 @@ var commandId = editor.addCommand(0, function() {
 
 monaco.languages.registerCodeLensProvider('json', {
     provideCodeLenses: function(model, token) {
-        return [
+        return {lenses: [
             {
                 range: {
                     startLineNumber: 1,
@@ -25,7 +25,7 @@ monaco.languages.registerCodeLensProvider('json', {
                     title: "First Line"
                 }
             }
-        ];
+        ]};
     },
     resolveCodeLens: function(model, codeLens, token) {
         return codeLens;


### PR DESCRIPTION
This PR fixes the playground example
https://microsoft.github.io/monaco-editor/playground.html#extending-language-services-codelens-provider-example

it is currently broken with error
![image](https://user-images.githubusercontent.com/5888506/71555963-5d48b980-2a32-11ea-8590-929472d3f866.png)
guess since https://github.com/microsoft/vscode/commit/35643d80e07f658c705b2b7dfba87b247c834a6b