### PR TITLE
Validate typings can be imported correctly in simple ts project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,17 @@ jobs:
         run: |
           yarn
           yarn gulp editor-distro
+      - name: Typings validation prep
+        run: |
+          mkdir typings-test
+      - name: Typings validation
+        working-directory: ./typings-test
+        run: |
+          yarn init -yp
+          yarn add typescript
+          yarn tsc --init
+          echo "import '../vscode/out-monaco-editor-core';" > a.ts
+          yarn tsc --noEmit
       - name: NPM Install
         run: npm install
       - name: Webpack Bundle


### PR DESCRIPTION
Ensure there is no error when using monaco-editor-core in a ts project