### PR TITLE
Added section in Monarch docs for Inspect Tokens development helper

### DIFF
--- a/website/monarch.html
+++ b/website/monarch.html
@@ -384,7 +384,7 @@ tokenizer: {
     <p>Only when we find a matching end tag (outside a string), <code>$1==$S2</code>, we pop the state and exit the embedded mode. Note that we need <a href="#@rematch"><code class="dt">@rematch</code></a> since the editor is ignoring our token classes until we actually exit the embedded mode (and we handle the close tag again in the <code>@root</code> state).</p>
 
     <p>&nbsp;</p>
-    <h2 id="htmlembed">Inspecting Tokens</h2>
+    <h2 id="inspectingtokens">Inspecting Tokens</h2>
 
     <p>Monaco provides an <code>Inspect Tokens</code> tool in browsers to help identify the tokens parsed from source code.</p>
     <p>To activate:</p>

--- a/website/monarch.html
+++ b/website/monarch.html
@@ -383,6 +383,17 @@ tokenizer: {
 ],</pre>
     <p>Only when we find a matching end tag (outside a string), <code>$1==$S2</code>, we pop the state and exit the embedded mode. Note that we need <a href="#@rematch"><code class="dt">@rematch</code></a> since the editor is ignoring our token classes until we actually exit the embedded mode (and we handle the close tag again in the <code>@root</code> state).</p>
 
+    <p>&nbsp;</p>
+    <h2 id="htmlembed">Inspecting Tokens</h2>
+
+    <p>Monaco provides an <code>Inspect Tokens</code> tool in browsers to help identify the tokens parsed from source code.</p>
+    <p>To activate:</p>
+    <ol>
+      <li>Press <kbd>F1</kbd> while focused on a Monaco instance</li>
+      <li>Trigger the <code>Developer: Inspect Tokens</code> option</li>
+    </ol>
+
+    <p>This will show a display over the currently selected token for its language, token type, basic font style and colors, and selector you can target in your editor themes.</p>
     </div> <!-- documentation -->
   </div> <!-- main -->
 


### PR DESCRIPTION
Fixes #1805 

![Screenshot of the updated text description](https://user-images.githubusercontent.com/3335181/73752421-f56f4800-472e-11ea-9d6d-2ec7fd60e177.png)

I'm not confident I captured the same phrasing & information style as the rest of the docs, and have no emotional attachment to the way it is now if you'd rather re-phrase!