### PR TITLE
ci: fixed smoke tests by increasing timeout

### DIFF
--- a/ci/core.test.ts
+++ b/ci/core.test.ts
@@ -10,13 +10,15 @@ type BrowserType = "chromium" | "firefox" | "webkit"
 
 const browserType: BrowserType = process.env.BROWSER as BrowserType || "chromium"
 
-before(async () => {
+before(async function () {
+    this.timeout(5 * 1000);
     console.log(`Starting browser: ${browserType}`)
     browser = await playwright[browserType].launch({
         headless: process.argv.includes('--headless'),
     });
 });
-after(async () => {
+after(async function () {
+    this.timeout(5 * 1000);
     await browser.close();
 });
 beforeEach(async function () {


### PR DESCRIPTION
Currently CI is still failing on GitHub Actions.
My guess is that Firefox takes sometimes longer than 2 seconds which is the default timeout, thats why Mocha is failing because it timeouts.
Should be a quick fix for now. Since we only want to check the basic functionality, it should be fine, otherwise I would recommend to e.g. migrate to Jest.