### PR TITLE
Adds support for both quotes in the TS side

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -196,6 +196,11 @@ function addPluginContribs(type) {
 				`define('vs/language/json/fillers/monaco-editor-core',[],`,
 				`define('vs/language/json/fillers/monaco-editor-core',['vs/editor/editor.api'],`,
 			);
+			// You can find both types of quotes in the TypeScript files
+			contribContents = contribContents.replace(
+				`define("vs/language/typescript/fillers/monaco-editor-core",[],`,
+				`define("vs/language/typescript/fillers/monaco-editor-core",['vs/editor/editor.api'],`,
+			);
 			contribContents = contribContents.replace(
 				`define('vs/language/typescript/fillers/monaco-editor-core',[],`,
 				`define('vs/language/typescript/fillers/monaco-editor-core',['vs/editor/editor.api'],`,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -185,29 +185,8 @@ function addPluginContribs(type) {
 			var contribContents = fs.readFileSync(contribPath).toString();
 
 			contribContents = contribContents.replace(
-				`define('vs/language/css/fillers/monaco-editor-core',[],`,
-				`define('vs/language/css/fillers/monaco-editor-core',['vs/editor/editor.api'],`,
-			);
-			contribContents = contribContents.replace(
-				`define('vs/language/html/fillers/monaco-editor-core',[],`,
-				`define('vs/language/html/fillers/monaco-editor-core',['vs/editor/editor.api'],`,
-			);
-			contribContents = contribContents.replace(
-				`define('vs/language/json/fillers/monaco-editor-core',[],`,
-				`define('vs/language/json/fillers/monaco-editor-core',['vs/editor/editor.api'],`,
-			);
-			// You can find both types of quotes in the TypeScript files
-			contribContents = contribContents.replace(
-				`define("vs/language/typescript/fillers/monaco-editor-core",[],`,
-				`define("vs/language/typescript/fillers/monaco-editor-core",['vs/editor/editor.api'],`,
-			);
-			contribContents = contribContents.replace(
-				`define('vs/language/typescript/fillers/monaco-editor-core',[],`,
-				`define('vs/language/typescript/fillers/monaco-editor-core',['vs/editor/editor.api'],`,
-			);
-			contribContents = contribContents.replace(
-				`define('vs/basic-languages/fillers/monaco-editor-core',[],`,
-				`define('vs/basic-languages/fillers/monaco-editor-core',['vs/editor/editor.api'],`,
+				/define\((['"][a-z\/\-]+\/fillers\/monaco-editor-core['"]),\[\],/,
+				'define($1,[\'vs/editor/editor.api\'],'
 			);
 
 			extraContent.push(contribContents);


### PR DESCRIPTION
TypeScript uses both `'` and `"` in the output, so only one of the contribution changes were being applied - re discussion in #2111 

![Screen Shot 2020-09-09 at 10 29 29 AM](https://user-images.githubusercontent.com/49038/92611753-1d0b2d80-f287-11ea-9859-ab4568d59125.png)
