### PR TITLE
fix: A 'declare' modifier cannot be used in an already ambient context

### DIFF
--- a/monaco.d.ts
+++ b/monaco.d.ts
@@ -6232,7 +6232,7 @@ declare namespace monaco.languages.typescript {
     interface MapLike<T> {
         [index: string]: T;
     }
-    declare type CompilerOptionsValue =
+    type CompilerOptionsValue =
         | string
         | number
         | boolean

--- a/package-lock.json
+++ b/package-lock.json
@@ -4328,9 +4328,9 @@
       "dev": true
     },
     "monaco-typescript": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/monaco-typescript/-/monaco-typescript-4.0.1.tgz",
-      "integrity": "sha512-FyVku1FEerPnHj1GYX3nzIhde3o2irRHg0mx5y0rGTjHZJlhpAlXcV4Bc+ufKqOGYZYtRQYtlR0sYwGs547KtA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/monaco-typescript/-/monaco-typescript-4.0.2.tgz",
+      "integrity": "sha512-Th3EjbKmEnQuCvGV09S/jm8x4RTjP7pvbI6cFCACl/IeSmwI9P69vzm68oI9pzMxZ0cLXjcye+bBKEHVayWi1Q==",
       "dev": true
     },
     "move-concurrently": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "monaco-html": "3.0.0",
     "monaco-json": "3.0.2",
     "monaco-languages": "2.0.0",
-    "monaco-typescript": "4.0.1",
+    "monaco-typescript": "4.0.2",
     "playwright": "1.3.0",
     "rimraf": "^3.0.2",
     "style-loader": "^1.2.1",

--- a/website/playground/monaco.d.ts.txt
+++ b/website/playground/monaco.d.ts.txt
@@ -6232,7 +6232,7 @@ declare namespace monaco.languages.typescript {
     interface MapLike<T> {
         [index: string]: T;
     }
-    declare type CompilerOptionsValue =
+    type CompilerOptionsValue =
         | string
         | number
         | boolean


### PR DESCRIPTION

```
Failed to compile.

/my-repo/node_modules/monaco-editor/esm/vs/editor/editor.api.d.ts
TypeScript error in /my-repo/node_modules/monaco-editor/esm/vs/editor/editor.api.d.ts(6235,5):
A 'declare' modifier cannot be used in an already ambient context.  TS1038

    6233 |         [index: string]: T;
    6234 |     }
  > 6235 |     declare type CompilerOptionsValue =
         |     ^
    6236 |         | string
    6237 |         | number
    6238 |         | boolean
```