### PR TITLE
Missing breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Fixes [a regression in monaco-css](https://github.com/microsoft/monaco-editor/issues/2158).
 
+### Breaking changes
+* `monaco.uri` methods `file, from, isUri, joinPath, parse, revive` are now static. Changing `new monaco.uri.method` to `monaco.uri.method` resolves 'TypeError: monaco.Uri.file is not a constructor at...' errors.
+
 ## [0.21.1] (24.09.2020)
 
 Fixes [a few regressions](https://github.com/microsoft/monaco-editor/issues?q=is%3Aissue+milestone%3A%22August+2020+%282%29%22+is%3Aclosed).


### PR DESCRIPTION
I'm not sure what release starting 0.21.0 caused it, not other methods being static now beyond parse() and file() in monaco.uri.
Regards and keep doing this amazing project awesomER!