### PR TITLE
Fixed indentation in C# sample

### DIFF
--- a/website/index/samples/sample.csharp.txt
+++ b/website/index/samples/sample.csharp.txt
@@ -12,7 +12,7 @@ namespace VS
 	class Program
 	{
 		static void Main(string[] args)
-    		{
+		{
 			bool isPrime = true;
 			Console.WriteLine("Prime Numbers : ");
 			for (int i = 2; i <= 100; i++)


### PR DESCRIPTION
One line used spaces instead of tabs, which meant the code appeared to be incorrectly indented:

![](https://user-images.githubusercontent.com/287848/101360610-29ab1c00-389e-11eb-8187-70cb03b42d09.png)
