### PR TITLE
Fix error message in Safari - Semantic token play

### DIFF
--- a/website/playground/new-samples/extending-language-services/semantic-tokens-provider-example/sample.js
+++ b/website/playground/new-samples/extending-language-services/semantic-tokens-provider-example/sample.js
@@ -35,7 +35,7 @@ function getModifier(modifiers) {
     }
 }
 
-const tokenPattern = new RegExp('(?<=\\[)([a-zA-Z]+)((?:\\.[a-zA-Z]+)*)(?=\\])', 'g');
+const tokenPattern = new RegExp('([a-zA-Z]+)((?:\\.[a-zA-Z]+)*)', 'g');
 
 monaco.languages.registerDocumentSemanticTokensProvider('plaintext', {
     getLegend: function () {


### PR DESCRIPTION
Fix for "SyntaxError: Invalid regular expression: invalid group specifier name" error displayed in editor, with Safari (version 14 or previous).

Linked to "Lookbehind in JS regular expressions", not supported in Safari: https://caniuse.com/js-regexp-lookbehind

See https://github.com/microsoft/monaco-editor/issues/2459 for details