### PR TITLE
Exposed colors sample update in the playground.

### DIFF
--- a/test/playground.generated/customizing-the-appearence-exposed-colors.html
+++ b/test/playground.generated/customizing-the-appearence-exposed-colors.html
@@ -141,6 +141,7 @@ monaco.editor.create(document.getElementById("container"), {
 'editorWhitespace.foreground' // Color of whitespace characters in the editor.
 'editorIndentGuide.background' // Color of the editor indentation guides.
 'editorLineNumber.foreground' // Color of editor line numbers.
+'editorLineNumber.activeForeground' // Color of editor active line number.
 'editorRuler.foreground' // Color of the editor rulers.
 'editorCodeLens.foreground' // Foreground color of editor code lenses
 'editorBracketMatch.background' // Background color behind matching brackets

--- a/website/playground/new-samples/customizing-the-appearence/exposed-colors/sample.js
+++ b/website/playground/new-samples/customizing-the-appearence/exposed-colors/sample.js
@@ -104,6 +104,7 @@ monaco.editor.create(document.getElementById("container"), {
 'editorWhitespace.foreground' // Color of whitespace characters in the editor.
 'editorIndentGuide.background' // Color of the editor indentation guides.
 'editorLineNumber.foreground' // Color of editor line numbers.
+'editorLineNumber.activeForeground' // Color of editor active line number.
 'editorRuler.foreground' // Color of the editor rulers.
 'editorCodeLens.foreground' // Foreground color of editor code lenses
 'editorBracketMatch.background' // Background color behind matching brackets


### PR DESCRIPTION
According to the pr https://github.com/microsoft/monaco-editor/issues/2507 
I decided to update the color which was missing in the issue. 
`editorActiveLineNumber.foreground` is [deprecated](https://github.com/microsoft/vscode/blob/3718ef05565efeb27e7ee29e50ee77fc82458bb0/src/vs/editor/common/view/editorColorRegistry.ts#L28) so I've added `editorLineNumber.activeForeground` token instead.