### PR TITLE
Small update on the website playground

### DIFF
--- a/website/playground/new-samples/customizing-the-appearence/exposed-colors/sample.js
+++ b/website/playground/new-samples/customizing-the-appearence/exposed-colors/sample.js
@@ -140,7 +140,7 @@ monaco.editor.create(document.getElementById("container"), {
 'peekViewEditor.matchHighlightBackground' // Match highlight color in the peek view editor.
 
 /*
-var colors = require('vs/platform/registry/common/platform').Registry.data['base.contributions.colors'].colorSchema.properties
+var colors = require('vs/platform/registry/common/platform').Registry.data.get('base.contributions.colors').colorSchema.properties
 Object.keys(colors).forEach(function(key) {
     var val = colors[key];
     console.log( '//' + val.description + '\n' + key);

--- a/website/playground/new-samples/extending-language-services/configure-javascript-defaults/sample.js
+++ b/website/playground/new-samples/extending-language-services/configure-javascript-defaults/sample.js
@@ -1,4 +1,4 @@
-// Add additonal d.ts files to the JavaScript language service and change.
+// Add additional d.ts files to the JavaScript language service and change.
 // Also change the default compilation options.
 // The sample below shows how a class Facts is declared and introduced
 // to the system and how the compiler is told to use ES6 (target=2).

--- a/website/playground/new-samples/interacting-with-the-editor/adding-an-action-to-an-editor-instance/sample.js
+++ b/website/playground/new-samples/interacting-with-the-editor/adding-an-action-to-an-editor-instance/sample.js
@@ -42,7 +42,7 @@ editor.addAction({
 	contextMenuOrder: 1.5,
 
 	// Method that will be executed when the action is triggered.
-	// @param editor The editor instance is passed in as a convinience
+	// @param editor The editor instance is passed in as a convenience
 	run: function(ed) {
 		alert("i'm running => " + ed.getPosition());
 		return null;

--- a/website/playground/new-samples/interacting-with-the-editor/listening-to-key-events/sample.js
+++ b/website/playground/new-samples/interacting-with-the-editor/listening-to-key-events/sample.js
@@ -7,4 +7,5 @@ var myBinding = editor.addCommand(monaco.KeyCode.F9, function() {
 	alert('F9 pressed!');
 });
 
-// When cleaning up remember to call myBinding.dispose()
+// You can't dispose `addCommand`
+// If you need to dispose it you might use `addAction` or `registerCommand`


### PR DESCRIPTION
Hi. 
I added 3 small fixes. Two of them are spelling corrections and the other one is an outdated comment
We can't `dispose` `addCommand` anymore... It can create confusion .