### PR TITLE
Fix letter case in repo URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "module": "./esm/vs/editor/editor.main.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/monaco-editor"
+    "url": "https://github.com/microsoft/monaco-editor"
   },
   "devDependencies": {
     "clean-css": "^5.1.1",


### PR DESCRIPTION
The repo url in `package.json` is incorrectly using uppercase in the origanization name, fix that.