### PR TITLE
Semantic Tokens Provider Sample is broken in docs

### DIFF
--- a/monaco-editor/website/playground/new-samples/extending-language-services/semantic-tokens-provider-example/sample.js
+++ b/monaco-editor/website/playground/new-samples/extending-language-services/semantic-tokens-provider-example/sample.js
@@ -110,6 +110,7 @@ monaco.languages.registerDocumentSemanticTokensProvider('plaintext', {
 monaco.editor.defineTheme('myCustomTheme', {
 	base: 'vs',
 	inherit: true,
+	colors : {},
 	rules: [
 		{ token: 'comment', foreground: 'aaaaaa', fontStyle: 'italic' },
 		{ token: 'keyword', foreground: 'ce63eb' },


### PR DESCRIPTION
# Semantic Tokens Provider Sample is broken in docs

- [Semantic Tokens Provider Sample Playground Link](https://microsoft.github.io/monaco-editor/playground.html#extending-language-services-semantic-tokens-provider-example)

## Video related to the issue

https://user-images.githubusercontent.com/29809906/141407743-72cdc5d5-32f3-4473-8220-df6d55c3b996.mov

## Description
- Issue occurred due to the missing colors key in the defineTheme API's ThemeDataObject
- The colors key seems to be **required** as it is not mentioned as optional in the [Interface IStandaloneThemeData](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneThemeData.html)
- Adding colors key in the ThemeDataObject fixes the issue