### PR TITLE
Expose the TypeScript object inside the ts worker

### DIFF
--- a/src/typescript/tsWorker.ts
+++ b/src/typescript/tsWorker.ts
@@ -494,3 +494,6 @@ export function create(ctx: worker.IWorkerContext, createData: ICreateData): Typ
 
 	return new TSWorkerClass(ctx, createData);
 }
+
+/** Allows for clients to have access to the same version of TypeScript that the worker uses */
+export const typescript = ts;

--- a/src/typescript/tsWorker.ts
+++ b/src/typescript/tsWorker.ts
@@ -496,4 +496,4 @@ export function create(ctx: worker.IWorkerContext, createData: ICreateData): Typ
 }
 
 /** Allows for clients to have access to the same version of TypeScript that the worker uses */
-export const typescript = ts;
+globalThis.ts = ts;

--- a/test/smoke/runner.js
+++ b/test/smoke/runner.js
@@ -35,6 +35,9 @@ yaserver
 	});
 
 async function runTests() {
+	// uncomment to shortcircuit and run a specific combo
+	// await runTest('webpack', 'chromium'); return;
+
 	for (const type of ['amd', 'webpack']) {
 		await runTest(type, 'chromium');
 		await runTest(type, 'firefox');

--- a/test/smoke/smoke.test.js
+++ b/test/smoke/smoke.test.js
@@ -64,10 +64,6 @@ afterEach(async () => {
 });
 
 describe(`Smoke Test '${TESTS_TYPE}'`, () => {
-	it('`monacoAPI` is exposed as global', async () => {
-		assert.strictEqual(await page.evaluate(`typeof monacoAPI`), 'object');
-	});
-
 	/**
 	 * @param {string} text
 	 * @param {string} language
@@ -104,6 +100,10 @@ describe(`Smoke Test '${TESTS_TYPE}'`, () => {
 	async function focusEditor() {
 		await page.evaluate(`window.ed.focus();`);
 	}
+
+	it('`monacoAPI` is exposed as global', async () => {
+		assert.strictEqual(await page.evaluate(`typeof monacoAPI`), 'object');
+	});
 
 	it('should be able to create plaintext editor', async () => {
 		await createEditor('hello world', 'plaintext');
@@ -162,6 +162,16 @@ describe(`Smoke Test '${TESTS_TYPE}'`, () => {
 
 		// check that a suggestion item for `addEventListener` appears, which indicates that the language service is up and running
 		await page.waitForSelector(`text=addEventListener`);
+
+		// find the TypeScript worker
+		const tsWorker = page.workers().find((worker) => {
+			const url = worker.url();
+			return /ts\.worker\.js$/.test(url) || /workerMain.js#typescript$/.test(url);
+		});
+		assert.ok(!!tsWorker);
+
+		// check that the TypeScript worker exposes `ts` as a global
+		assert.strictEqual(await tsWorker.evaluate(`typeof ts`), 'object');
 	});
 });
 


### PR DESCRIPTION
I've migrated our infra over to handle the new monorepo, but hit a blocker. In the older versions of monaco-typescript, importing `vs/language/typescript/tsWorker` would trigger `window.ts` to become the TypeScript object. 

This is _generally_ considered a  feature (of a side effect) when importing typescriptServices.js because of this `var`:

![Screen Shot 2021-11-15 at 10 40 02 PM](https://user-images.githubusercontent.com/49038/141864048-e6af41dc-30f2-4f97-a536-280cc7be4801.png)
 
I used that to access the same version of TypeScript as the monaco webworker in the Playground. 

I'm not tied to the implementation detail as it's easy to do both, so I felt this might be more ESM-y instead of jamming a `window.ts = ts` at the end but I think it depends on whether this is classed as a breaking change (and I guess if other people used that side-effect) in which case this can be switched out