### PR TITLE
Remove return from example addAction

### DIFF
--- a/monaco-editor/website/playground/new-samples/interacting-with-the-editor/adding-an-action-to-an-editor-instance/sample.js
+++ b/monaco-editor/website/playground/new-samples/interacting-with-the-editor/adding-an-action-to-an-editor-instance/sample.js
@@ -48,6 +48,5 @@ editor.addAction({
 	// @param editor The editor instance is passed in as a convenience
 	run: function (ed) {
 		alert("i'm running => " + ed.getPosition());
-		return null;
 	}
 });


### PR DESCRIPTION
Documentation for [`editor.AddAction`](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IActionDescriptor.html#run) gives a return type of `void | Promise<void>`. Having the example `return null` is confusing given it doesn't really matter what it returns.