### PR TITLE
Expose full ts object to global ts

### DIFF
--- a/build/importTypescript.js
+++ b/build/importTypescript.js
@@ -134,6 +134,7 @@ export var IndentStyle = ts.IndentStyle;
 export var ScriptKind = ts.ScriptKind;
 export var ScriptTarget = ts.ScriptTarget;
 export var TokenClass = ts.TokenClass;
+export var typescript = ts;
 // END MONACOCHANGE
 `;
 	fs.writeFileSync(

--- a/src/typescript/tsWorker.ts
+++ b/src/typescript/tsWorker.ts
@@ -496,4 +496,5 @@ export function create(ctx: worker.IWorkerContext, createData: ICreateData): Typ
 }
 
 /** Allows for clients to have access to the same version of TypeScript that the worker uses */
-globalThis.ts = ts;
+// @ts-ignore
+globalThis.ts = ts.typescript;

--- a/test/smoke/smoke.test.js
+++ b/test/smoke/smoke.test.js
@@ -172,6 +172,9 @@ describe(`Smoke Test '${TESTS_TYPE}'`, () => {
 
 		// check that the TypeScript worker exposes `ts` as a global
 		assert.strictEqual(await tsWorker.evaluate(`typeof ts`), 'object');
+
+		// check that the TypeScript worker exposes the full `ts` as a global
+		assert.strictEqual(await tsWorker.evaluate(`typeof ts.optionDeclarations`), 'object');
 	});
 });
 


### PR DESCRIPTION
It looks like the prior PR https://github.com/microsoft/monaco-editor/pull/2770 was close, but not quite. The object available is the exported set of vars at the end of `typescriptServices.js`: 

![Screen Shot 2021-11-16 at 2 46 55 PM](https://user-images.githubusercontent.com/49038/142007024-20607e45-b206-4123-9016-b0ddb158e613.png)

Which isn't the typescript API, just a subset (used for ESM support I assume) - this means you don't get access to the underlaying `ts`.  To work around this, I've done a bit of a dance of exporting `typescript` from this object and then later adding that to the `globalThis`.

To validate, I've added to the smoketest for a non-exported property from the TypeScript compiler API. Nice test suite BTW 👍🏻 

---

I took a look at what changed in the JS between:

 - monorepo: https://typescript.azureedge.net/cdn/4.6.0-dev.20211115/monaco/dev/vs/language/typescript/tsWorker.js
 - before: https://typescript.azureedge.net/cdn/4.4.4/monaco/dev/vs/language/typescript/tsWorker.js

Which looks to roughly be that the script _didn't_ use umd-style requires and that's probably what used to set the top level as now it gets scoped into the function because they live in a "use strict" context.