### PR TITLE
Fix token while missing `syntax=` directive

### DIFF
--- a/src/basic-languages/protobuf/protobuf.ts
+++ b/src/basic-languages/protobuf/protobuf.ts
@@ -133,9 +133,10 @@ export const language = <languages.IMonarchLanguage>{
 				/(")(proto2)(")/,
 				['string.quote', 'string', { token: 'string.quote', switchTo: '@topLevel.proto2' }]
 			],
-			[	 // If no `syntax` provided, regarded as proto2
-			  /.*?/,
-			  { token: '', switchTo: '@topLevel.proto2' }
+			[
+				// If no `syntax` provided, regarded as proto2
+				/.*?/,
+				{ token: '', switchTo: '@topLevel.proto2' }
 			]
 		],
 

--- a/src/basic-languages/protobuf/protobuf.ts
+++ b/src/basic-languages/protobuf/protobuf.ts
@@ -132,6 +132,10 @@ export const language = <languages.IMonarchLanguage>{
 			[
 				/(")(proto2)(")/,
 				['string.quote', 'string', { token: 'string.quote', switchTo: '@topLevel.proto2' }]
+			],
+			[	 // If no `syntax` provided, regarded as proto2
+			  /.*?/,
+			  { token: '', switchTo: '@topLevel.proto2' }
 			]
 		],
 


### PR DESCRIPTION
see this issue. https://github.com/microsoft/monaco-editor/issues/2700 Just simply `switchTo` proto2 token if there is no `sytanx=` provided.