### PR TITLE
Support hyphenated HTML tags in Markdown syntax

### DIFF
--- a/src/basic-languages/markdown/markdown.test.ts
+++ b/src/basic-languages/markdown/markdown.test.ts
@@ -43,5 +43,53 @@ testTokenization('markdown', [
 				{ startIndex: 11, type: 'string.link.md' }
 			]
 		}
+	],
+
+	// simple HTML content
+	[
+		{
+			line: '<div>content</div>',
+			tokens: [
+				{ startIndex: 0, type: 'tag.md' },
+				{ startIndex: 5, type: '' },
+				{ startIndex: 12, type: 'tag.md' }
+			]
+		}
+	],
+
+	// hyphenated HTML tag
+	[
+		{
+			line: '<custom-component>content</custom-component>',
+			tokens: [
+				{ startIndex: 0, type: 'tag.md' },
+				{ startIndex: 18, type: '' },
+				{ startIndex: 25, type: 'tag.md' }
+			]
+		}
+	],
+
+	// unclosed HTML tag without hyphens and a trailing character
+	[
+		{
+			line: '<div',
+			tokens: [{ startIndex: 0, type: 'tag.md' }]
+		}
+	],
+
+	// unclosed HTML tag with trailing hyphen
+	[
+		{
+			line: '<custom-',
+			tokens: [{ startIndex: 0, type: 'tag.md' }]
+		}
+	],
+
+	// unclosed HTML tag with hyphen and a trailing characer
+	[
+		{
+			line: '<custom-component',
+			tokens: [{ startIndex: 0, type: 'tag.md' }]
+		}
 	]
 ]);

--- a/src/basic-languages/markdown/markdown.ts
+++ b/src/basic-languages/markdown/markdown.ts
@@ -166,7 +166,7 @@ export const language = <languages.IMonarchLanguage>{
 			// html tags
 			[/<(\w+)\/>/, 'tag'],
 			[
-				/<(\w+)/,
+				/<(\w+)(\-|\w)*/,
 				{
 					cases: {
 						'@empty': { token: 'tag', next: '@tag.$1' },
@@ -174,7 +174,7 @@ export const language = <languages.IMonarchLanguage>{
 					}
 				}
 			],
-			[/<\/(\w+)\s*>/, { token: 'tag' }],
+			[/<\/(\w+)(\-|\w)*\s*>/, { token: 'tag' }],
 
 			[/<!--/, 'comment', '@comment']
 		],


### PR DESCRIPTION
This fixes #2863.