### PR TITLE
Fix #2851 Highlight correctly the attributes and identifiers (with dashes) for Shell language

### DIFF
--- a/src/basic-languages/shell/shell.test.ts
+++ b/src/basic-languages/shell/shell.test.ts
@@ -33,6 +33,40 @@ testTokenization('shell', [
 				{ startIndex: 14, type: 'white.shell' },
 				{ startIndex: 15, type: '' }
 			]
+		},
+		// Tests for case reported in bug #2851, do not confuse identifier(with dashes) with attribute
+		{
+			line: 'foo-bar --baz gorp -123 --abc-123',
+			tokens: [
+				{ startIndex: 0, type: '' },
+				{ startIndex: 7, type: 'white.shell' },
+				{ startIndex: 8, type: 'attribute.name.shell' },
+				{ startIndex: 13, type: 'white.shell' },
+				{ startIndex: 14, type: '' },
+				{ startIndex: 18, type: 'white.shell' },
+				{ startIndex: 19, type: 'attribute.name.shell' },
+				{ startIndex: 23, type: 'white.shell' },
+				{ startIndex: 24, type: 'attribute.name.shell' }
+			]
+		},
+		// Bug #2851 add new definition 'Identifiers with dashes', here one test
+		{
+			line: 'foo | foo-bar | foo-bar-1 | foo-bar-2021-1',
+			tokens: [
+				{ startIndex: 0, type: '' },
+				{ startIndex: 3, type: 'white.shell' },
+				{ startIndex: 4, type: 'delimiter.shell' },
+				{ startIndex: 5, type: 'white.shell' },
+				{ startIndex: 6, type: '' },
+				{ startIndex: 13, type: 'white.shell' },
+				{ startIndex: 14, type: 'delimiter.shell' },
+				{ startIndex: 15, type: 'white.shell' },
+				{ startIndex: 16, type: '' },
+				{ startIndex: 25, type: 'white.shell' },
+				{ startIndex: 26, type: 'delimiter.shell' },
+				{ startIndex: 27, type: 'white.shell' },
+				{ startIndex: 28, type: '' }
+			]
 		}
 	],
 

--- a/src/basic-languages/shell/shell.ts
+++ b/src/basic-languages/shell/shell.ts
@@ -134,13 +134,19 @@ export const language = <languages.IMonarchLanguage>{
 		'zsh'
 	],
 
+	startingWithDash: /\-+\w+/,
+
+	identifiersWithDashes: /[a-zA-Z]\w+(?:@startingWithDash)+/,
+
 	// we include these common regular expressions
 	symbols: /[=><!~?&|+\-*\/\^;\.,]+/,
 
 	// The main tokenizer for our languages
 	tokenizer: {
 		root: [
-			{ include: '@whitespace' },
+			[/@identifiersWithDashes/, ''],
+
+			[/(\s)((?:@startingWithDash)+)/, ['white', 'attribute.name']],
 
 			[
 				/[a-zA-Z]\w*/,
@@ -153,13 +159,13 @@ export const language = <languages.IMonarchLanguage>{
 				}
 			],
 
+			{ include: '@whitespace' },
+
 			{ include: '@strings' },
 			{ include: '@parameters' },
 			{ include: '@heredoc' },
 
 			[/[{}\[\]()]/, '@brackets'],
-
-			[/-+\w+/, 'attribute.name'],
 
 			[/@symbols/, 'delimiter'],
 


### PR DESCRIPTION
This PR fix #2851. The fix is correcting the regex that highlight the attributes and create a new regex for identifiers containing dashes.

This impact the Monaco editor playground only.

You can test by running the tests:
>npm run release
>npm run test

Two new tests added, one for the bug reported and one for the new regex defined (identifiers with dashes).