### PR TITLE
Improved module specification in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"watch": "tsc -w -p ./src"
 	},
 	"typings": "./esm/vs/editor/editor.api.d.ts",
-	"module": "./esm/vs/editor/editor.main.js",
+	"type": "module",
+	"main": "./esm/vs/editor/editor.main.js",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/monaco-editor"


### PR DESCRIPTION
It's not really valid according to the spec to not have a `main` field. If you are distributing multiple versions like CJS and ESM you can specify one in `main` and the ESM in `module`, but you shouldn't ever really have a missing `main` field. If the main is an ESM file you can simply specify `"type": "module"`