### PR TITLE
Add @preconcurrency to Swift declaration attributes

### DIFF
--- a/src/basic-languages/swift/swift.ts
+++ b/src/basic-languages/swift/swift.ts
@@ -57,8 +57,8 @@ export const language = <languages.IMonarchLanguage>{
 		'@asyncHandler',
 		'@available',
 		'@convention',
-		'@derivative', // Swift for TensorFlow
-		'@differentiable', // Swift for TensorFlow
+		'@derivative',
+		'@differentiable',
 		'@discardableResult',
 		'@dynamicCallable',
 		'@dynamicMemberLookup',
@@ -72,6 +72,7 @@ export const language = <languages.IMonarchLanguage>{
 		'@noreturn',
 		'@objc',
 		'@objcMembers',
+		'@preconcurrency',
 		'@propertyWrapper',
 		'@requires_stored_property_inits',
 		'@resultBuilder',
@@ -317,11 +318,6 @@ export const language = <languages.IMonarchLanguage>{
 			[/`/, { token: 'operator', next: '@pop' }],
 			[/./, 'identifier']
 		],
-
-		//		symbol: [
-		//			[ /@symbols/, 'operator' ],
-		//			[ /@operators/, 'operator' ]
-		//		],
 
 		invokedmethod: [
 			[


### PR DESCRIPTION
Citing [this pull request](https://github.com/apple/swift/pull/41022), the Core Swift team has decided on adding the new keyword to Swift 5.6. This will also ensure that syntax coloring for Swift-Colab is as up-to-date as possible if Google suddenly ups their monaco dependency from 0.27 to current.