### PR TITLE
Only run publish workflow on main monaco-editor repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ on:
         default: 'true'
 jobs:
   publish:
+    if: github.repository == "microsoft/monaco-editor"
     name: Publish to npm
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Currently, the publish workflow will automatically run in any fork of the main repo, triggering an action failure once a week.

This PR adjusts the workflow so that it'll check if it's running in the main repo before attempting to run the job, so it'll continue to work the same in the main repo, and just not run at all in forks.

This could also be applied to the other workflows that run on cron jobs if desired.