### PR TITLE
Add .cjs extension for javascript files

### DIFF
--- a/src/basic-languages/javascript/javascript.contribution.ts
+++ b/src/basic-languages/javascript/javascript.contribution.ts
@@ -10,7 +10,7 @@ declare var require: any;
 
 registerLanguage({
 	id: 'javascript',
-	extensions: ['.js', '.es6', '.jsx', '.mjs'],
+	extensions: ['.js', '.es6', '.jsx', '.mjs', '.cjs'],
 	firstLine: '^#!.*\\bnode',
 	filenames: ['jakefile'],
 	aliases: ['JavaScript', 'javascript', 'js'],


### PR DESCRIPTION
This extension is used by node projects of `"type": "module"` for files that are still written using CommonJS (for example configuration files).