### PR TITLE
Properly mark files as external

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -39,7 +39,7 @@ dts(
 buildESM({
 	base: 'css',
 	entryPoints: ['src/css/monaco.contribution.ts', 'src/css/cssMode.ts', 'src/css/css.worker.ts'],
-	external: ['monaco-editor-core', '*/cssMode']
+	external: ['monaco-editor-core', '*/cssMode', '*/monaco.contribution']
 });
 buildAMD({
 	base: 'css',
@@ -69,7 +69,7 @@ buildESM({
 		'src/html/htmlMode.ts',
 		'src/html/html.worker.ts'
 	],
-	external: ['monaco-editor-core', '*/htmlMode']
+	external: ['monaco-editor-core', '*/htmlMode', '*/monaco.contribution']
 });
 buildAMD({
 	base: 'html',
@@ -99,7 +99,7 @@ buildESM({
 		'src/json/jsonMode.ts',
 		'src/json/json.worker.ts'
 	],
-	external: ['monaco-editor-core', '*/jsonMode']
+	external: ['monaco-editor-core', '*/jsonMode', '*/monaco.contribution']
 });
 buildAMD({
 	base: 'json',
@@ -134,7 +134,7 @@ buildESM({
 		'src/typescript/tsMode.ts',
 		'src/typescript/ts.worker.ts'
 	],
-	external: ['monaco-editor-core', '*/tsMode']
+	external: ['monaco-editor-core', '*/tsMode', '*/monaco.contribution']
 });
 buildAMD({
 	base: 'typescript',


### PR DESCRIPTION
Without it, some code is duplicated at the end.

The creation of the `LanguageServiceDefaultsImpl` are in both `monaco.contribution.js` AND `tsMode.js`

The first time the `typescript` language is used, `tsMode` is dynamically imported from `monaco.contribution`, which reset the `typescriptDefaults`/`javascriptDefaults` by creating new instances of `LanguageServiceDefaultsImpl`

fix for https://github.com/microsoft/monaco-editor/issues/2931
