### PR TITLE
Add script type module syntax highlighting to html

### DIFF
--- a/src/basic-languages/html/html.test.ts
+++ b/src/basic-languages/html/html.test.ts
@@ -396,6 +396,32 @@ testTokenization(
 			}
 		],
 
+		// Embedded Content #10
+		[
+			{
+				line: '<script type="module">var i= 10;</script>',
+				tokens: [
+					{ startIndex: 0, type: 'delimiter.html' },
+					{ startIndex: 1, type: 'tag.html' },
+					{ startIndex: 7, type: '' },
+					{ startIndex: 8, type: 'attribute.name.html' },
+					{ startIndex: 12, type: 'delimiter.html' },
+					{ startIndex: 13, type: 'attribute.value.html' },
+					{ startIndex: 21, type: 'delimiter.html' },
+					{ startIndex: 22, type: 'keyword.js' },
+					{ startIndex: 25, type: '' },
+					{ startIndex: 26, type: 'identifier.js' },
+					{ startIndex: 27, type: 'delimiter.js' },
+					{ startIndex: 28, type: '' },
+					{ startIndex: 29, type: 'number.js' },
+					{ startIndex: 31, type: 'delimiter.js' },
+					{ startIndex: 32, type: 'delimiter.html' },
+					{ startIndex: 34, type: 'tag.html' },
+					{ startIndex: 40, type: 'delimiter.html' }
+				]
+			}
+		],
+
 		// Tag with Attribute
 		[
 			{

--- a/src/basic-languages/html/html.ts
+++ b/src/basic-languages/html/html.ts
@@ -161,6 +161,20 @@ export const language = <languages.IMonarchLanguage>{
 		// After <script ... type =
 		scriptAfterTypeEquals: [
 			[
+				/"module"/,
+				{
+					token: 'attribute.value',
+					switchTo: '@scriptWithCustomType.text/javascript'
+				}
+			],
+			[
+				/'module'/,
+				{
+					token: 'attribute.value',
+					switchTo: '@scriptWithCustomType.text/javascript'
+				}
+			],
+			[
 				/"([^"]*)"/,
 				{
 					token: 'attribute.value',


### PR DESCRIPTION
This enables JavaScript syntax highlighting in embedded script tags with the attribute type set to module in html files. E.g.

```html
<script type="module">
  // Syntax highlighting works here.
  function printSum(a, b) {
    console.log(`Sum is ${a + b}`);
  }
</script>
```

(type module causes the code to be treated as a JavaScript module. [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#type))