### PR TITLE
Upgrade ts-node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"pretty-quick": "^3.1.3",
 				"requirejs": "^2.3.6",
 				"terser": "^5.10.0",
-				"ts-node": "^10.4.0",
+				"ts-node": "^10.6.0",
 				"typedoc": "^0.22.11",
 				"typescript": "4.5.5",
 				"vscode-css-languageservice": "^5.1.12",
@@ -2629,9 +2629,9 @@
 			}
 		},
 		"node_modules/ts-node": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
-			"integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.6.0.tgz",
+			"integrity": "sha512-CJen6+dfOXolxudBQXnVjRVvYTmTWbyz7cn+xq2XTsvnaXbHqr4gXSCNbS2Jj8yTZMuGwUoBESLaOkLascVVvg==",
 			"dev": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.7.0",
@@ -2645,6 +2645,7 @@
 				"create-require": "^1.1.0",
 				"diff": "^4.0.1",
 				"make-error": "^1.1.1",
+				"v8-compile-cache-lib": "^3.0.0",
 				"yn": "3.1.1"
 			},
 			"bin": {
@@ -2751,6 +2752,12 @@
 			"engines": {
 				"node": ">= 4.0.0"
 			}
+		},
+		"node_modules/v8-compile-cache-lib": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
+			"integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
+			"dev": true
 		},
 		"node_modules/vscode-css-languageservice": {
 			"version": "5.1.12",
@@ -4904,9 +4911,9 @@
 			}
 		},
 		"ts-node": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
-			"integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.6.0.tgz",
+			"integrity": "sha512-CJen6+dfOXolxudBQXnVjRVvYTmTWbyz7cn+xq2XTsvnaXbHqr4gXSCNbS2Jj8yTZMuGwUoBESLaOkLascVVvg==",
 			"dev": true,
 			"requires": {
 				"@cspotcode/source-map-support": "0.7.0",
@@ -4920,6 +4927,7 @@
 				"create-require": "^1.1.0",
 				"diff": "^4.0.1",
 				"make-error": "^1.1.1",
+				"v8-compile-cache-lib": "^3.0.0",
 				"yn": "3.1.1"
 			},
 			"dependencies": {
@@ -4975,6 +4983,12 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
+		},
+		"v8-compile-cache-lib": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
+			"integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
 			"dev": true
 		},
 		"vscode-css-languageservice": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"pretty-quick": "^3.1.3",
 		"requirejs": "^2.3.6",
 		"terser": "^5.10.0",
+		"ts-node": "^10.6.0",
 		"typedoc": "^0.22.11",
 		"typescript": "4.5.5",
 		"vscode-css-languageservice": "^5.1.12",
@@ -56,7 +57,6 @@
 		"vscode-languageserver-textdocument": "^1.0.4",
 		"vscode-languageserver-types": "3.16.0",
 		"vscode-uri": "3.0.3",
-		"yaserver": "^0.4.0",
-		"ts-node": "^10.4.0"
+		"yaserver": "^0.4.0"
 	}
 }


### PR DESCRIPTION
monaco-typescript builds of TypeScript 4.6 and nightlies are failing due to a TS API change that ts-node needed to account for: https://github.com/microsoft/TypeScript/issues/47921 / https://github.com/TypeStrong/ts-node/pull/1648. The ts-node fix was just published to v10.6. We need this in order to get new versions of TypeScript up on the playground. Thanks!