### PR TITLE
Add new required methods to LanguageServiceHost

### DIFF
--- a/src/language/typescript/tsWorker.ts
+++ b/src/language/typescript/tsWorker.ts
@@ -181,6 +181,14 @@ export class TypeScriptWorker implements ts.LanguageServiceHost, ITypeScriptWork
 		return fileName === this.getDefaultLibFileName(this._compilerOptions);
 	}
 
+	readFile(path: string): string | undefined {
+		return this._getScriptText(path);
+	}
+
+	fileExists(path: string): boolean {
+		return this._getScriptText(path) !== undefined;
+	}
+
 	async getLibFiles(): Promise<Record<string, string>> {
 		return libFileMap;
 	}


### PR DESCRIPTION
The comment from @weswigham on these methods says

```
/*
 * Unlike `realpath and `readDirectory`, `readFile` and `fileExists` are now _required_
 * to properly acquire and setup source files under module: node12+ modes.
 */
```

Obviously monaco-editor can’t read files, so I assume this is the closest we’re going to get. I’m not sure when/if these methods will get called, but the Playground does let you select node12/nodenext module settings, so I think throwing a not-implemented error would likely show up. @weswigham can you review please?