### PR TITLE
Improve the instruction for each Webpack version.

### DIFF
--- a/webpack-plugin/README.md
+++ b/webpack-plugin/README.md
@@ -30,12 +30,21 @@ module.exports = {
 			},
 			{
 				test: /\.ttf$/,
-				use: ['file-loader']
+				type: 'asset/resource'
 			}
 		]
 	},
 	plugins: [new MonacoWebpackPlugin()]
 };
+```
+
+If using Webpack 4 or lower, it is necessary to use the file-loader instead of Asset Modules like the code below:
+
+```js
+{
+	test: /\.ttf$/,
+	use: ['file-loader']
+}
 ```
 
 - `index.js`:


### PR DESCRIPTION
If using Webpack 5 or higher, the loading `*.ttf` files are failed due to using the file-loader module.

![Screenshot_20220330_162711](https://user-images.githubusercontent.com/261787/160980755-62720aa5-1982-4bbe-97bf-acd80789e259.png)

It is necessary to use Asset Modules since Webpack 5 or higher instead of the file-loader.

```js
{
    test: /\.ttf$/,
    type: 'asset/resource'
}
```

That is, the current instruction guide on the README.md file is for Webpack 4 or lower. I wan to improve the guide for Webpack 5 or higher users by this pull request.