### PR TITLE
[DOCS] IEditorOptions.automaticLayout uses ResizeObserver 3051

### DIFF
--- a/website/typedoc/monaco.d.ts
+++ b/website/typedoc/monaco.d.ts
@@ -2947,7 +2947,7 @@ declare namespace monaco.editor {
          */
         smoothScrolling?: boolean;
         /**
-         * Enable that the editor will install an interval to check if its container dom node size has changed.
+         * Enable that the editor will install a ResizeObserver to check if its container dom node size has changed.
          * Enabling this might have a severe performance impact.
          * Defaults to false.
          */


### PR DESCRIPTION
fixes: #3051