### PR TITLE
Add yaml indent action

### DIFF
--- a/src/basic-languages/yaml/yaml.ts
+++ b/src/basic-languages/yaml/yaml.ts
@@ -1,4 +1,4 @@
-import type { languages } from '../../fillers/monaco-editor-core';
+import { languages } from '../../fillers/monaco-editor-core';
 
 export const conf: languages.LanguageConfiguration = {
 	comments: {
@@ -25,7 +25,15 @@ export const conf: languages.LanguageConfiguration = {
 	],
 	folding: {
 		offSide: true
-	}
+	},
+	onEnterRules: [
+		{
+			beforeText: /:\s*$/,
+			action: {
+				indentAction: languages.IndentAction.Indent
+			}
+		}
+	]
 };
 
 export const language = <languages.IMonarchLanguage>{


### PR DESCRIPTION
If a line ends with `:` and a user presses Enter, they are probably defining an object, which requires indentation.

[This rule is taken from `monaco-yaml`](https://github.com/remcohaszing/monaco-yaml/blob/main/src/yamlMode.ts#L41-L45), but I intend to remove basic language support there, since that’s already part of `monaco-editor`.