### PR TITLE
add `out` keyword to typescript

### DIFF
--- a/src/basic-languages/typescript/typescript.ts
+++ b/src/basic-languages/typescript/typescript.ts
@@ -127,6 +127,7 @@ export const language = {
 		'null',
 		'number',
 		'object',
+		'out',
 		'package',
 		'private',
 		'protected',


### PR DESCRIPTION
see https://github.com/microsoft/TypeScript-Website/issues/2329 and https://devblogs.microsoft.com/typescript/announcing-typescript-4-7-beta/#optional-variance-annotations-for-type-parameters