### PR TITLE
feat: add fr units for css grid

### DIFF
--- a/src/basic-languages/css/css.ts
+++ b/src/basic-languages/css/css.ts
@@ -165,7 +165,7 @@ export const language = <languages.IMonarchLanguage>{
 
 		units: [
 			[
-				'(em|ex|ch|rem|vmin|vmax|vw|vh|vm|cm|mm|in|px|pt|pc|deg|grad|rad|turn|s|ms|Hz|kHz|%)?',
+				'(em|ex|ch|rem|fr|vmin|vmax|vw|vh|vm|cm|mm|in|px|pt|pc|deg|grad|rad|turn|s|ms|Hz|kHz|%)?',
 				'attribute.value.unit',
 				'@pop'
 			]

--- a/src/basic-languages/less/less.ts
+++ b/src/basic-languages/less/less.ts
@@ -164,7 +164,7 @@ export const language = <languages.IMonarchLanguage>{
 
 		units: [
 			[
-				'(em|ex|ch|rem|vmin|vmax|vw|vh|vm|cm|mm|in|px|pt|pc|deg|grad|rad|turn|s|ms|Hz|kHz|%)?',
+				'(em|ex|ch|rem|fr|vmin|vmax|vw|vh|vm|cm|mm|in|px|pt|pc|deg|grad|rad|turn|s|ms|Hz|kHz|%)?',
 				'attribute.value.unit',
 				'@pop'
 			]

--- a/src/basic-languages/scss/scss.ts
+++ b/src/basic-languages/scss/scss.ts
@@ -187,7 +187,7 @@ export const language = <languages.IMonarchLanguage>{
 
 		units: [
 			[
-				'(em|ex|ch|rem|vmin|vmax|vw|vh|vm|cm|mm|in|px|pt|pc|deg|grad|rad|turn|s|ms|Hz|kHz|%)?',
+				'(em|ex|ch|rem|fr|vmin|vmax|vw|vh|vm|cm|mm|in|px|pt|pc|deg|grad|rad|turn|s|ms|Hz|kHz|%)?',
 				'number',
 				'@pop'
 			]


### PR DESCRIPTION
Adds the fr units to all of the styling syntax highlighting. The `fr` units represents fractions of the avaliable space and is used in the CSS Grid.