### PR TITLE
Fix false-positive check in `provideCompletionItems` method

### DIFF
--- a/src/language/typescript/languageFeatures.ts
+++ b/src/language/typescript/languageFeatures.ts
@@ -474,7 +474,7 @@ export class SuggestAdapter extends Adapter implements languages.CompletionItemP
 			}
 
 			const tags: languages.CompletionItemTag[] = [];
-			if (entry.kindModifiers?.indexOf('deprecated') !== -1) {
+			if (entry.kindModifiers && entry.kindModifiers.indexOf('deprecated') >= 0) {
 				tags.push(languages.CompletionItemTag.Deprecated);
 			}
 


### PR DESCRIPTION
If entry.kindModifiers is undefined, then whole condition was true (because undefined !== -1), causing marking entry as deprecated.