### PR TITLE
Fix menu link in integrate-esm.md

### DIFF
--- a/docs/integrate-esm.md
+++ b/docs/integrate-esm.md
@@ -1,7 +1,7 @@
 ## Integrating the ESM version of the Monaco Editor
 
 - [Webpack](#using-webpack)
-  - [Option 1: Using the Monaco Editor Loader Plugin](#option-1-using-the-monaco-editor-loader-plugin)
+  - [Option 1: Using the Monaco Editor WebPack Plugin](#option-1-using-the-monaco-editor-webpack-plugin)
   - [Option 2: Using plain webpack](#option-2-using-plain-webpack)
 - [Parcel](#using-parcel)
 - [Vite](#using-vite)


### PR DESCRIPTION
There is a missing in `integrate-esm.md`, make the link be not working.