### PR TITLE
Export `CustomTSWebWorkerFactory` type

### DIFF
--- a/src/language/typescript/monaco.contribution.ts
+++ b/src/language/typescript/monaco.contribution.ts
@@ -6,6 +6,7 @@
 import type * as mode from './tsMode';
 import { typescriptVersion as tsversion } from './lib/typescriptServicesMetadata'; // do not import the whole typescriptServices here
 import { languages, Emitter, IEvent, IDisposable, Uri } from '../../fillers/monaco-editor-core';
+export { CustomTSWebWorkerFactory } from './tsWorker';
 
 //#region enums copied from typescript to prevent loading the entire typescriptServices ---
 


### PR DESCRIPTION
It would be great if this type could get exported, it would help people to have good type guarantees when authoring custom web worker factories.

⚠️ This doesn't currently work because in the generated `.d.ts` this export is not resolved/inlined and this is left behind:
```ts
export { CustomTSWebWorkerFactory } from './tsWorker';
```
which doesn't work in this context because `./tsWorker` doesn't exist anymore in this context and because exports like this are not permitted within namespaces.

I'm not sure what I should tweak here to make it work. Should I tweak something in the build script? Or should I juggle the code around and move required types from `./tsWorker` to `monaco.contribution.ts` and import them from `monaco.contribution.ts` to `./tsWorker`?