### PR TITLE
add perl module (.pm) extension

### DIFF
--- a/src/basic-languages/perl/perl.contribution.ts
+++ b/src/basic-languages/perl/perl.contribution.ts
@@ -10,7 +10,7 @@ declare var require: any;
 
 registerLanguage({
 	id: 'perl',
-	extensions: ['.pl'],
+	extensions: ['.pl', '.pm'],
 	aliases: ['Perl', 'pl'],
 	loader: () => {
 		if (AMD) {


### PR DESCRIPTION
The .pm extension is perl's module or library extension by convention.