### PR TITLE
Update @types/node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "monaco-editor",
-	"version": "0.33.0",
+	"version": "0.34.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "monaco-editor",
-			"version": "0.33.0",
+			"version": "0.34.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"devDependencies": {
@@ -164,9 +164,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.14.tgz",
-			"integrity": "sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==",
+			"version": "18.7.23",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.23.tgz",
+			"integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
 			"dev": true
 		},
 		"node_modules/@types/yauzl": {
@@ -3270,9 +3270,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "17.0.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.14.tgz",
-			"integrity": "sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==",
+			"version": "18.7.23",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.23.tgz",
+			"integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
 			"dev": true
 		},
 		"@types/yauzl": {


### PR DESCRIPTION
There was a compatibility issue with TypeScript 4.9 Beta in @types/node that was fixed in a recent version. This unblocks TypeScript Playground builds of the beta. Thanks!