### PR TITLE
Use transformer to remove require calls and nodeSystem from typescript.js

### DIFF
--- a/build/importTypescript.ts
+++ b/build/importTypescript.ts
@@ -35,9 +35,7 @@ const TYPESCRIPT_LIB_DESTINATION = path.join(REPO_ROOT, 'src/language/typescript
 export const typescriptVersion = "${typeScriptDependencyVersion}";\n`
 	);
 
-	let tsServices = fs
-		.readFileSync(path.join(TYPESCRIPT_LIB_SOURCE, 'typescriptServices.js'))
-		.toString();
+	let tsServices = fs.readFileSync(path.join(TYPESCRIPT_LIB_SOURCE, 'typescript.js')).toString();
 
 	// Ensure we never run into the node system...
 	// (this also removes require calls that trick webpack into shimming those modules...)
@@ -149,14 +147,8 @@ export var typescript = ts;
 		stripSourceMaps(tsServices_esm)
 	);
 
-	let dtsServices = fs
-		.readFileSync(path.join(TYPESCRIPT_LIB_SOURCE, 'typescriptServices.d.ts'))
-		.toString();
-	dtsServices += `
-// MONACOCHANGE
-export = ts;
-// END MONACOCHANGE
-`;
+	let dtsServices = fs.readFileSync(path.join(TYPESCRIPT_LIB_SOURCE, 'typescript.d.ts')).toString();
+
 	fs.writeFileSync(
 		path.join(TYPESCRIPT_LIB_DESTINATION, 'typescriptServices.d.ts'),
 		generatedNote + dtsServices

--- a/build/importTypescript.ts
+++ b/build/importTypescript.ts
@@ -114,20 +114,20 @@ export const typescriptVersion = "${typeScriptDependencyVersion}";\n`
 	tsServices = transformed.outputText;
 
 	tsServices = tsServices.replace(
-		/^( +)debugger;$/m,
+		/^( +)debugger;$/gm,
 		'$1// MONACOCHANGE\n$1// debugger;\n$1// END MONACOCHANGE'
 	);
 	tsServices = tsServices.replace(
-		/typeof require === "function"/m,
+		/typeof require === "function"/g,
 		'/* MONACOCHANGE */ false /* END MONACOCHANGE */'
 	);
 	tsServices = tsServices.replace(
-		/typeof require !== "undefined"/m,
+		/typeof require !== "undefined"/g,
 		'/* MONACOCHANGE */ false /* END MONACOCHANGE */'
 	);
 
 	tsServices = tsServices.replace(
-		/module.exports = ts;/m,
+		/module.exports = ts;/g,
 		'/* MONACOCHANGE */ /*module.exports = ts;*/ /* END MONACOCHANGE */'
 	);
 

--- a/build/importTypescript.ts
+++ b/build/importTypescript.ts
@@ -105,7 +105,7 @@ export const typescriptVersion = "${typeScriptDependencyVersion}";\n`
 				!l.includes(': diag(') &&
 				!l.includes('ts.DiagnosticCategory') &&
 				!/`[^`]*require[^`]+`/.test(l) &&
-                                !/"[^"]*require[^"]+"/.test(l) // hack
+ 				!/"[^"]*require[^"]+"/.test(l) // hack
 		);
 
 	if (runtimeRequires && runtimeRequires.length && linesWithRequire) {

--- a/build/importTypescript.ts
+++ b/build/importTypescript.ts
@@ -104,7 +104,8 @@ export const typescriptVersion = "${typeScriptDependencyVersion}";\n`
 			(l) =>
 				!l.includes(': diag(') &&
 				!l.includes('ts.DiagnosticCategory') &&
-				!/`[^`]*require[^`]+`/.test(l)
+				!/`[^`]*require[^`]+`/.test(l) &&
+                                !/"[^"]*require[^"]+"/.test(l) // hack
 		);
 
 	if (runtimeRequires && runtimeRequires.length && linesWithRequire) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -164,9 +164,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.14.tgz",
-			"integrity": "sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==",
+			"version": "18.7.23",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.23.tgz",
+			"integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
 			"dev": true
 		},
 		"node_modules/@types/yauzl": {
@@ -3270,9 +3270,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "17.0.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.14.tgz",
-			"integrity": "sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==",
+			"version": "18.7.23",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.23.tgz",
+			"integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
 			"dev": true
 		},
 		"@types/yauzl": {

--- a/src/language/typescript/lib/typescriptServices.d.ts
+++ b/src/language/typescript/lib/typescriptServices.d.ts
@@ -7594,6 +7594,4 @@ declare namespace ts {
     const isIdentifierOrPrivateIdentifier: (node: Node) => node is MemberName;
 }
 
-// MONACOCHANGE
 export = ts;
-// END MONACOCHANGE


### PR DESCRIPTION
This includes #3344; I would merge that in first and then I'll rebase this one as it's more complicated.

Right now, the build script uses source level hacks to remove require calls and such. But with https://github.com/microsoft/TypeScript/issues/49332 on the horizon, these source level hacks are going to be unstable.

Rather than try and maintain all of these regex replacements, rewrite the code using transpileModule. This should be a sure-fire method as we can use the helper TS uses to identify require calls and replace them with no-ops.

I've removed the part of the script which complains about leftover requires, as the transformer gets all of the "real" requires; anything left is a false positive from a string, or a call to `sys.require` which the transformer will also ensure is undefined as it removes the nodeSystem from use.

