### PR TITLE
Update vite sample in `docs/integrate-esm.md`

### DIFF
--- a/docs/integrate-esm.md
+++ b/docs/integrate-esm.md
@@ -192,32 +192,30 @@ Adding monaco editor to [Vite](https://vitejs.dev/) is simple since it has built
 
 ```js
 import * as monaco from 'monaco-editor';
+import JsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
+import CssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker';
+import HtmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker';
+import TsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
+import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 
 self.MonacoEnvironment = {
 	getWorker: function (workerId, label) {
-		const getWorkerModule = (moduleUrl, label) => {
-			return new Worker(self.MonacoEnvironment.getWorkerUrl(moduleUrl), {
-				name: label,
-				type: 'module'
-			});
-		};
-
 		switch (label) {
 			case 'json':
-				return getWorkerModule('/monaco-editor/esm/vs/language/json/json.worker?worker', label);
+				return new JsonWorker();
 			case 'css':
 			case 'scss':
 			case 'less':
-				return getWorkerModule('/monaco-editor/esm/vs/language/css/css.worker?worker', label);
+				return new CssWorker();
 			case 'html':
 			case 'handlebars':
 			case 'razor':
-				return getWorkerModule('/monaco-editor/esm/vs/language/html/html.worker?worker', label);
+				return new HtmlWorker();
 			case 'typescript':
 			case 'javascript':
-				return getWorkerModule('/monaco-editor/esm/vs/language/typescript/ts.worker?worker', label);
+				return new TsWorker();
 			default:
-				return getWorkerModule('/monaco-editor/esm/vs/editor/editor.worker?worker', label);
+				return new EditorWorker();
 		}
 	}
 };


### PR DESCRIPTION
### Description

The [vite sample](https://github.com/microsoft/monaco-editor/blob/main/docs/integrate-esm.md#using-vite) in `docs/integrate-esm.md` doesn't work properly:

![errors](https://user-images.githubusercontent.com/86521894/196694485-081e9562-0fcb-4980-a789-3f9fc263c34b.png)

### Reproduction

- OS: Windows11

- Browser: Microsoft Edge 106.0.1370.47

- Repository: [mys1024/monaco-with-vite (branch: main)](https://github.com/mys1024/monaco-with-vite/tree/main)

### Demo of updated vite sample

Repository: [mys1024/monaco-with-vite (branch: fix-vite-sample)](https://github.com/mys1024/monaco-with-vite/tree/fix-vite-sample)
