### PR TITLE
Update node types for TS 4.9 RC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "monaco-editor",
-	"version": "0.34.1",
+	"version": "0.35.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "monaco-editor",
-			"version": "0.34.1",
+			"version": "0.35.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"devDependencies": {
@@ -1692,9 +1692,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.7.23",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.23.tgz",
-			"integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
+			"version": "18.11.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz",
+			"integrity": "sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ==",
 			"dev": true
 		},
 		"node_modules/@types/parse-json": {
@@ -8040,9 +8040,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.7.23",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.23.tgz",
-			"integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
+			"version": "18.11.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz",
+			"integrity": "sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ==",
 			"dev": true
 		},
 		"@types/parse-json": {


### PR DESCRIPTION
TS 4.9 RC updates AbortSignal again, and requires a matching upgrade to `@types/node`. Followup to #3334. Required to compile against TS 4.9 RC or Typescript nightly builds.