### PR TITLE
Update import path for `browser-esm-webpack-small`

### DIFF
--- a/samples/browser-esm-webpack-small/index.js
+++ b/samples/browser-esm-webpack-small/index.js
@@ -17,7 +17,7 @@ import 'monaco-editor/esm/vs/editor/browser/controller/coreCommands.js';
 // import 'monaco-editor/esm/vs/editor/contrib/cursorUndo/cursorUndo.js';
 // import 'monaco-editor/esm/vs/editor/contrib/dnd/dnd.js';
 // import 'monaco-editor/esm/vs/editor/contrib/documentSymbols/documentSymbols.js';
-import 'monaco-editor/esm/vs/editor/contrib/find/findController.js';
+import 'monaco-editor/esm/vs/editor/contrib/find/browser/findController.js';
 // import 'monaco-editor/esm/vs/editor/contrib/folding/folding.js';
 // import 'monaco-editor/esm/vs/editor/contrib/fontZoom/fontZoom.js';
 // import 'monaco-editor/esm/vs/editor/contrib/format/formatActions.js';


### PR DESCRIPTION
The `npm run build` step for the `browser-esm-webpack-small` example is currently failing due to an outdated import path referencing `findController` in its `index.js`.

I've fixed the build by updating the import path to `findController`'s [current location](https://github.com/microsoft/vscode/blob/main/src/vs/editor/contrib/find/browser/findController.ts).