### PR TITLE
Set `always` to true to trigger a build even when there are no new commits.

### DIFF
--- a/.azure-pipelines/publish-nightly.yml
+++ b/.azure-pipelines/publish-nightly.yml
@@ -13,6 +13,7 @@ schedules:
     branches:
       include:
         - main
+    always: true
 
 resources:
   repositories:


### PR DESCRIPTION
This is because nightly is build from the latest vscode@main.