### PR TITLE
Ignore dist from vite/parcel in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,5 @@
 /test/manual/generated/
 /website/lib/
 /website/typedoc/monaco.d.ts
+/test/smoke/vite/dist
+/test/smoke/parcel/dist


### PR DESCRIPTION
This adds `/test/smoke/vite/dist` and `/test/smoke/parcel/dist` in `.prettierignore` -- whenever you build the project locally, these directories add unnecessary length to local formatting and don't need to be formatted as they are already ignored.