### PR TITLE
Add setModeConfiguration for monaco.languages.typescript.[typescript|javascript]Defaults

### DIFF
--- a/src/language/typescript/monaco.contribution.ts
+++ b/src/language/typescript/monaco.contribution.ts
@@ -226,6 +226,73 @@ interface OutputFile {
 	text: string;
 }
 
+export interface ModeConfiguration {
+	/**
+	 * Defines whether the built-in completionItemProvider is enabled.
+	 */
+	readonly completionItems?: boolean;
+
+	/**
+	 * Defines whether the built-in hoverProvider is enabled.
+	 */
+	readonly hovers?: boolean;
+
+	/**
+	 * Defines whether the built-in documentSymbolProvider is enabled.
+	 */
+	readonly documentSymbols?: boolean;
+
+	/**
+	 * Defines whether the built-in definitions provider is enabled.
+	 */
+	readonly definitions?: boolean;
+
+	/**
+	 * Defines whether the built-in references provider is enabled.
+	 */
+	readonly references?: boolean;
+
+	/**
+	 * Defines whether the built-in references provider is enabled.
+	 */
+	readonly documentHighlights?: boolean;
+
+	/**
+	 * Defines whether the built-in rename provider is enabled.
+	 */
+	readonly rename?: boolean;
+
+	/**
+	 * Defines whether the built-in diagnostic provider is enabled.
+	 */
+	readonly diagnostics?: boolean;
+
+	/**
+	 * Defines whether the built-in document formatting range edit provider is enabled.
+	 */
+	readonly documentRangeFormattingEdits?: boolean;
+
+	/**
+	 * Defines whether the built-in signature help provider is enabled.
+	 */
+	readonly signatureHelp?: boolean;
+
+	/**
+	 * Defines whether the built-in onType formatting edit provider is enabled.
+	 */
+	readonly onTypeFormattingEdits?: boolean;
+
+	/**
+	 * Defines whether the built-in code actions provider is enabled.
+	 */
+	readonly codeActions?: boolean;
+
+	/**
+	 * Defines whether the built-in inlay hints provider is enabled.
+	 */
+	readonly inlayHints?: boolean;
+}
+
 export interface LanguageServiceDefaults {
 	/**
 	 * Event fired when compiler options or diagnostics options are changed.
@@ -240,6 +307,9 @@ export interface LanguageServiceDefaults {
 	readonly workerOptions: WorkerOptions;
 
 	readonly inlayHintsOptions: InlayHintsOptions;
+
+	readonly modeConfiguration: ModeConfiguration;
+	setModeConfiguration(modeConfiguration: ModeConfiguration): void;
 
 	/**
 	 * Get the current extra libs registered with the language service.
@@ -491,12 +561,14 @@ class LanguageServiceDefaultsImpl implements LanguageServiceDefaults {
 	private _workerOptions!: WorkerOptions;
 	private _onDidExtraLibsChangeTimeout: number;
 	private _inlayHintsOptions!: InlayHintsOptions;
+	private _modeConfiguration!: ModeConfiguration;
 
 	constructor(
 		compilerOptions: CompilerOptions,
 		diagnosticsOptions: DiagnosticsOptions,
 		workerOptions: WorkerOptions,
-		inlayHintsOptions: InlayHintsOptions
+		inlayHintsOptions: InlayHintsOptions,
+		modeConfiguration: ModeConfiguration
 	) {
 		this._extraLibs = Object.create(null);
 		this._removedExtraLibs = Object.create(null);
@@ -505,6 +577,7 @@ class LanguageServiceDefaultsImpl implements LanguageServiceDefaults {
 		this.setDiagnosticsOptions(diagnosticsOptions);
 		this.setWorkerOptions(workerOptions);
 		this.setInlayHintsOptions(inlayHintsOptions);
+		this.setModeConfiguration(modeConfiguration);
 		this._onDidExtraLibsChangeTimeout = -1;
 	}
 
@@ -514,6 +587,10 @@ class LanguageServiceDefaultsImpl implements LanguageServiceDefaults {
 
 	get onDidExtraLibsChange(): IEvent<void> {
 		return this._onDidExtraLibsChange.event;
+	}
+
+	get modeConfiguration(): ModeConfiguration {
+		return this._modeConfiguration;
 	}
 
 	get workerOptions(): WorkerOptions {
@@ -650,22 +727,45 @@ class LanguageServiceDefaultsImpl implements LanguageServiceDefaults {
 	getEagerModelSync() {
 		return this._eagerModelSync;
 	}
+
+	setModeConfiguration(modeConfiguration: ModeConfiguration): void {
+		this._modeConfiguration = modeConfiguration || Object.create(null);
+		this._onDidChange.fire(undefined);
+	}
 }
 
 export const typescriptVersion: string = tsversion;
+
+const modeConfigurationDefault: Required<ModeConfiguration> = {
+	completionItems: true,
+	hovers: true,
+	documentSymbols: true,
+	definitions: true,
+	references: true,
+	documentHighlights: true,
+	rename: true,
+	diagnostics: true,
+	documentRangeFormattingEdits: true,
+	signatureHelp: true,
+	onTypeFormattingEdits: true,
+	codeActions: true,
+	inlayHints: true
+};
 
 export const typescriptDefaults: LanguageServiceDefaults = new LanguageServiceDefaultsImpl(
 	{ allowNonTsExtensions: true, target: ScriptTarget.Latest },
 	{ noSemanticValidation: false, noSyntaxValidation: false, onlyVisible: false },
 	{},
-	{}
+	{},
+	modeConfigurationDefault
 );
 
 export const javascriptDefaults: LanguageServiceDefaults = new LanguageServiceDefaultsImpl(
 	{ allowNonTsExtensions: true, allowJs: true, target: ScriptTarget.Latest },
 	{ noSemanticValidation: true, noSyntaxValidation: false, onlyVisible: false },
 	{},
-	{}
+	{},
+	modeConfigurationDefault
 );
 
 export const getTypeScriptWorker = (): Promise<(...uris: Uri[]) => Promise<TypeScriptWorker>> => {

--- a/src/language/typescript/tsMode.ts
+++ b/src/language/typescript/tsMode.ts
@@ -7,7 +7,7 @@ import { WorkerManager } from './workerManager';
 import type { TypeScriptWorker } from './tsWorker';
 import { LanguageServiceDefaults } from './monaco.contribution';
 import * as languageFeatures from './languageFeatures';
-import { languages, Uri } from '../../fillers/monaco-editor-core';
+import { languages, IDisposable, Uri } from '../../fillers/monaco-editor-core';
 
 let javaScriptWorker: (...uris: Uri[]) => Promise<TypeScriptWorker>;
 let typeScriptWorker: (...uris: Uri[]) => Promise<TypeScriptWorker>;
@@ -44,45 +44,132 @@ function setupMode(
 	defaults: LanguageServiceDefaults,
 	modeId: string
 ): (...uris: Uri[]) => Promise<TypeScriptWorker> {
+	const disposables: IDisposable[] = [];
+	const providers: IDisposable[] = [];
+
 	const client = new WorkerManager(modeId, defaults);
+	disposables.push(client);
+
 	const worker = (...uris: Uri[]): Promise<TypeScriptWorker> => {
 		return client.getLanguageServiceWorker(...uris);
 	};
 
 	const libFiles = new languageFeatures.LibFiles(worker);
 
-	languages.registerCompletionItemProvider(modeId, new languageFeatures.SuggestAdapter(worker));
-	languages.registerSignatureHelpProvider(
-		modeId,
-		new languageFeatures.SignatureHelpAdapter(worker)
-	);
-	languages.registerHoverProvider(modeId, new languageFeatures.QuickInfoAdapter(worker));
-	languages.registerDocumentHighlightProvider(
-		modeId,
-		new languageFeatures.OccurrencesAdapter(worker)
-	);
-	languages.registerDefinitionProvider(
-		modeId,
-		new languageFeatures.DefinitionAdapter(libFiles, worker)
-	);
-	languages.registerReferenceProvider(
-		modeId,
-		new languageFeatures.ReferenceAdapter(libFiles, worker)
-	);
-	languages.registerDocumentSymbolProvider(modeId, new languageFeatures.OutlineAdapter(worker));
-	languages.registerDocumentRangeFormattingEditProvider(
-		modeId,
-		new languageFeatures.FormatAdapter(worker)
-	);
-	languages.registerOnTypeFormattingEditProvider(
-		modeId,
-		new languageFeatures.FormatOnTypeAdapter(worker)
-	);
-	languages.registerCodeActionProvider(modeId, new languageFeatures.CodeActionAdaptor(worker));
-	languages.registerRenameProvider(modeId, new languageFeatures.RenameAdapter(libFiles, worker));
-	languages.registerInlayHintsProvider(modeId, new languageFeatures.InlayHintsAdapter(worker));
-	new languageFeatures.DiagnosticsAdapter(libFiles, defaults, modeId, worker);
+	function registerProviders(): void {
+		const { modeConfiguration } = defaults;
+
+		disposeAll(providers);
+
+		if (modeConfiguration.completionItems) {
+			providers.push(
+				languages.registerCompletionItemProvider(
+					modeId,
+					new languageFeatures.SuggestAdapter(worker)
+				)
+			);
+		}
+		if (modeConfiguration.signatureHelp) {
+			providers.push(
+				languages.registerSignatureHelpProvider(
+					modeId,
+					new languageFeatures.SignatureHelpAdapter(worker)
+				)
+			);
+		}
+		if (modeConfiguration.hovers) {
+			providers.push(
+				languages.registerHoverProvider(modeId, new languageFeatures.QuickInfoAdapter(worker))
+			);
+		}
+		if (modeConfiguration.documentHighlights) {
+			providers.push(
+				languages.registerDocumentHighlightProvider(
+					modeId,
+					new languageFeatures.OccurrencesAdapter(worker)
+				)
+			);
+		}
+		if (modeConfiguration.definitions) {
+			providers.push(
+				languages.registerDefinitionProvider(
+					modeId,
+					new languageFeatures.DefinitionAdapter(libFiles, worker)
+				)
+			);
+		}
+		if (modeConfiguration.references) {
+			providers.push(
+				languages.registerReferenceProvider(
+					modeId,
+					new languageFeatures.ReferenceAdapter(libFiles, worker)
+				)
+			);
+		}
+		if (modeConfiguration.documentSymbols) {
+			providers.push(
+				languages.registerDocumentSymbolProvider(
+					modeId,
+					new languageFeatures.OutlineAdapter(worker)
+				)
+			);
+		}
+		if (modeConfiguration.rename) {
+			providers.push(
+				languages.registerRenameProvider(
+					modeId,
+					new languageFeatures.RenameAdapter(libFiles, worker)
+				)
+			);
+		}
+		if (modeConfiguration.documentRangeFormattingEdits) {
+			providers.push(
+				languages.registerDocumentRangeFormattingEditProvider(
+					modeId,
+					new languageFeatures.FormatAdapter(worker)
+				)
+			);
+		}
+		if (modeConfiguration.onTypeFormattingEdits) {
+			providers.push(
+				languages.registerOnTypeFormattingEditProvider(
+					modeId,
+					new languageFeatures.FormatOnTypeAdapter(worker)
+				)
+			);
+		}
+		if (modeConfiguration.codeActions) {
+			providers.push(
+				languages.registerCodeActionProvider(modeId, new languageFeatures.CodeActionAdaptor(worker))
+			);
+		}
+		if (modeConfiguration.inlayHints) {
+			providers.push(
+				languages.registerInlayHintsProvider(modeId, new languageFeatures.InlayHintsAdapter(worker))
+			);
+		}
+		if (modeConfiguration.diagnostics) {
+			providers.push(new languageFeatures.DiagnosticsAdapter(libFiles, defaults, modeId, worker));
+		}
+	}
+
+	registerProviders();
+
+	disposables.push(asDisposable(providers));
+
+	//return asDisposable(disposables);
+
 	return worker;
+}
+
+function asDisposable(disposables: IDisposable[]): IDisposable {
+	return { dispose: () => disposeAll(disposables) };
+}
+
+function disposeAll(disposables: IDisposable[]) {
+	while (disposables.length) {
+		disposables.pop()!.dispose();
+	}
 }
 
 export { WorkerManager } from './workerManager';


### PR DESCRIPTION
This commit implements the functionality requested in #3155.
The work is done based on the implementation for the the css, html and json namespaces.

In this case the `ModeConfiguration` interface implementation has the following options:

```typescript
export interface ModeConfiguration {
	/**
	 * Defines whether the built-in completionItemProvider is enabled.
	 */
	readonly completionItems?: boolean;

	/**
	 * Defines whether the built-in hoverProvider is enabled.
	 */
	readonly hovers?: boolean;

	/**
	 * Defines whether the built-in documentSymbolProvider is enabled.
	 */
	readonly documentSymbols?: boolean;

	/**
	 * Defines whether the built-in definitions provider is enabled.
	 */
	readonly definitions?: boolean;

	/**
	 * Defines whether the built-in references provider is enabled.
	 */
	readonly references?: boolean;

	/**
	 * Defines whether the built-in references provider is enabled.
	 */
	readonly documentHighlights?: boolean;

	/**
	 * Defines whether the built-in rename provider is enabled.
	 */
	readonly rename?: boolean;

	/**
	 * Defines whether the built-in diagnostic provider is enabled.
	 */
	readonly diagnostics?: boolean;

	/**
	 * Defines whether the built-in document formatting range edit provider is enabled.
	 */
	readonly documentRangeFormattingEdits?: boolean;

	/**
	 * Defines whether the built-in signature help provider is enabled.
	 */
	readonly signatureHelp?: boolean;

	/**
	 * Defines whether the built-in onType formatting edit provider is enabled.
	 */
	readonly onTypeFormattingEdits?: boolean;

	/**
	 * Defines whether the built-in code actions provider is enabled.
	 */
	readonly codeActions?: boolean;

	/**
	 * Defines whether the built-in inlay hints provider is enabled.
	 */
	readonly inlayHints?: boolean;
}
```
There are some notes though:

The `setupMode` implementations for css, html and json return an `IDisposable` containing all disposable elements created during the function execution. But the `setupMode` implementation for typescript returns `(...uris: Uri[]) => Promise<TypeScriptWorker>` containing the worker function. So I implemented the code to collect all disposable elements, but it's useless so far, waiting to be reviewed in future commit.
