### PR TITLE
Add .props & .targets as XML extensions

### DIFF
--- a/src/basic-languages/xml/xml.contribution.ts
+++ b/src/basic-languages/xml/xml.contribution.ts
@@ -17,6 +17,7 @@ registerLanguage({
 		'.csproj',
 		'.config',
 		'.props',
+		'.targets',
 		'.wxi',
 		'.wxl',
 		'.wxs',

--- a/src/basic-languages/xml/xml.contribution.ts
+++ b/src/basic-languages/xml/xml.contribution.ts
@@ -16,6 +16,7 @@ registerLanguage({
 		'.ascx',
 		'.csproj',
 		'.config',
+		'.props',
 		'.wxi',
 		'.wxl',
 		'.wxs',


### PR DESCRIPTION
Directory.Build.props and Directory.Build.targets are commonly used in C# solutions.  (See https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2022.)  These have the usual MSBuild syntax, which is just XML (c.f. `.csproj`).

Note - if the PR needs to be updated to be `.Build.props` and `.Build.targets` that's fine.