### PR TITLE
Update @types/node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1809,9 +1809,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.14.tgz",
-			"integrity": "sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng=="
+			"version": "18.13.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+			"integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
 		},
 		"node_modules/@types/parse-json": {
 			"version": "4.0.0",
@@ -8437,9 +8437,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "17.0.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.14.tgz",
-			"integrity": "sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng=="
+			"version": "18.13.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+			"integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
 		},
 		"@types/parse-json": {
 			"version": "4.0.0",


### PR DESCRIPTION
Playground builds are broken again with an `AbortSignal` type error, and I’m hazarding a guess this fixes it.