### PR TITLE
Update README Playground Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please note that this repository contains no source code for the code editor, it
 
 ## Try it out
 
-Try the editor out [on our website](https://microsoft.github.io/monaco-editor/index.html).
+Try the editor out [on our website](https://microsoft.github.io/monaco-editor/playground.html?source=v0.35.0)
 
 ## Installing
 


### PR DESCRIPTION
The link in the README to try the editor is dead.

Updated with a proper link to the playground.