### PR TITLE
Fix the sample 'model-markers-example' compilation failure

### DIFF
--- a/website/src/website/data/playground-samples/extending-language-services/model-markers-example/sample.js
+++ b/website/src/website/data/playground-samples/extending-language-services/model-markers-example/sample.js
@@ -41,7 +41,9 @@ abcd
 234.56`;
 const uri = monaco.Uri.parse("inmemory://test");
 const model = monaco.editor.createModel(value, "demoLanguage", uri);
-editor = monaco.editor.create(document.getElementById("container"), { model });
+const editor = monaco.editor.create(document.getElementById("container"), {
+	model,
+});
 validate(model);
 model.onDidChangeContent(() => {
 	validate(model);


### PR DESCRIPTION
When I was learning Monaco Editor from the playground, I saw that the sample 'model-markers-example' did not work.

Before:
<img width="1116" alt="before" src="https://user-images.githubusercontent.com/28998859/219584698-01e3f6cc-7b49-4740-b373-a9fe2a4e5305.png">

After:
<img width="1114" alt="after" src="https://user-images.githubusercontent.com/28998859/219584746-3643085b-d058-4ed2-b5f5-836a4c8202b6.png">

