### PR TITLE
fix: fix hover example

### DIFF
--- a/website/src/website/data/playground-samples/extending-language-services/hover-provider-example/sample.js
+++ b/website/src/website/data/playground-samples/extending-language-services/hover-provider-example/sample.js
@@ -2,7 +2,7 @@ monaco.languages.register({ id: "mySpecialLanguage" });
 
 monaco.languages.registerHoverProvider("mySpecialLanguage", {
 	provideHover: function (model, position) {
-		return xhr("../playground.html").then(function (res) {
+		return xhr("./playground.html").then(function (res) {
 			return {
 				range: new monaco.Range(
 					1,


### PR DESCRIPTION
when I visit monaco editor website， I find [this example](https://microsoft.github.io/monaco-editor/playground.html?source=v0.35.0#example-extending-language-services-hover-provider-example) is error。 can't get playground.html, and 404。

Then I git clone monaco editor and run dev。 finally I find that after website restructure， the file `playground.html`  at root directory。