### PR TITLE
Fix 'Hover Provider Example' incorrect Promise syntax

### DIFF
--- a/website/src/website/data/playground-samples/extending-language-services/hover-provider-example/sample.js
+++ b/website/src/website/data/playground-samples/extending-language-services/hover-provider-example/sample.js
@@ -31,35 +31,32 @@ monaco.editor.create(document.getElementById("container"), {
 
 function xhr(url) {
 	var req = null;
-	return new Promise(
-		function (c, e) {
-			req = new XMLHttpRequest();
-			req.onreadystatechange = function () {
-				if (req._canceled) {
-					return;
+	return new Promise(function (c, e) {
+		req = new XMLHttpRequest();
+		req.onreadystatechange = function () {
+			if (req._canceled) {
+				return;
+			}
+
+			if (req.readyState === 4) {
+				if (
+					(req.status >= 200 && req.status < 300) ||
+					req.status === 1223
+				) {
+					c(req);
+				} else {
+					e(req);
 				}
+				req.onreadystatechange = function () {};
+			}
+		};
 
-				if (req.readyState === 4) {
-					if (
-						(req.status >= 200 && req.status < 300) ||
-						req.status === 1223
-					) {
-						c(req);
-					} else {
-						e(req);
-					}
-					req.onreadystatechange = function () {};
-				}
-			};
+		req.open("GET", url, true);
+		req.responseType = "";
 
-			req.open("GET", url, true);
-			req.responseType = "";
-
-			req.send(null);
-		},
-		function () {
-			req._canceled = true;
-			req.abort();
-		}
-	);
+		req.send(null);
+	}).catch(function () {
+		req._canceled = true;
+		req.abort();
+	});
 }


### PR DESCRIPTION
The example [Hover Provider Example](https://microsoft.github.io/monaco-editor/playground.html?source=v0.35.0#example-extending-language-services-hover-provider-example) has incorrect Promise syntax, It doesn't affect the operation, but I still fixed it.