### PR TITLE
opt example 

### DIFF
--- a/website/src/website/data/playground-samples/creating-the-editor/hard-wrapping/sample.js
+++ b/website/src/website/data/playground-samples/creating-the-editor/hard-wrapping/sample.js
@@ -8,9 +8,6 @@ var editor = monaco.editor.create(document.getElementById("container"), {
 	wordWrap: "wordWrapColumn",
 	wordWrapColumn: 40,
 
-	// Set this to false to not auto word wrap minified files
-	wordWrapMinified: true,
-
 	// try "same", "indent" or "none"
 	wrappingIndent: "indent",
 });


### PR DESCRIPTION
example 
https://microsoft.github.io/monaco-editor/playground.html?source=v0.35.0#example-creating-the-editor-hard-wrapping

opt example, remove new version not support attr `wordWrapMinified` on create editor。