### PR TITLE
Replace occurrences with highlights

### DIFF
--- a/src/language/typescript/monaco.contribution.ts
+++ b/src/language/typescript/monaco.contribution.ts
@@ -440,13 +440,10 @@ export interface TypeScriptWorker {
 	 */
 	getQuickInfoAtPosition(fileName: string, position: number): Promise<any | undefined>;
 
-	/**
-	 * Get other ranges which are related to the item at the given position in the file (often used for highlighting).
-	 * @returns `Promise<ReadonlyArray<typescript.ReferenceEntry> | undefined>`
-	 */
-	getOccurrencesAtPosition(
+	getDocumentHighlights(
 		fileName: string,
-		position: number
+		position: number,
+		filesToSearch: string[]
 	): Promise<ReadonlyArray<any> | undefined>;
 
 	/**

--- a/src/language/typescript/tsMode.ts
+++ b/src/language/typescript/tsMode.ts
@@ -86,7 +86,7 @@ function setupMode(
 			providers.push(
 				languages.registerDocumentHighlightProvider(
 					modeId,
-					new languageFeatures.OccurrencesAdapter(worker)
+					new languageFeatures.DocumentHighlightAdapter(worker)
 				)
 			);
 		}

--- a/src/language/typescript/tsWorker.ts
+++ b/src/language/typescript/tsWorker.ts
@@ -299,14 +299,15 @@ export class TypeScriptWorker implements ts.LanguageServiceHost, ITypeScriptWork
 		return this._languageService.getQuickInfoAtPosition(fileName, position);
 	}
 
-	async getOccurrencesAtPosition(
+	async getDocumentHighlights(
 		fileName: string,
-		position: number
-	): Promise<ReadonlyArray<ts.ReferenceEntry> | undefined> {
+		position: number,
+		filesToSearch: string[]
+	): Promise<ReadonlyArray<ts.DocumentHighlights> | undefined> {
 		if (fileNameIsLib(fileName)) {
 			return undefined;
 		}
-		return this._languageService.getOccurrencesAtPosition(fileName, position);
+		return this._languageService.getDocumentHighlights(fileName, position, filesToSearch);
 	}
 
 	async getDefinitionAtPosition(


### PR DESCRIPTION
We just removed this in https://github.com/microsoft/TypeScript/pull/52347 but now we can't build the playground (oops).

Somehow we didn't find this use. We have had document highlights for a good while, so we can use it here.