### PR TITLE
Add a `customTypeScriptPath` option which should point to a script which defines a global `ts`

### DIFF
--- a/src/language/typescript/monaco.contribution.ts
+++ b/src/language/typescript/monaco.contribution.ts
@@ -164,6 +164,8 @@ export interface DiagnosticsOptions {
 }
 
 export interface WorkerOptions {
+	/** A full HTTP path to a typescript.js file that will define a global `ts` which the worker will use */
+	customTypeScriptPath?: string;
 	/** A full HTTP path to a JavaScript file which adds a function `customTSWorkerFactory` to the self inside a web-worker */
 	customWorkerPath?: string;
 }

--- a/src/language/typescript/workerManager.ts
+++ b/src/language/typescript/workerManager.ts
@@ -70,6 +70,7 @@ export class WorkerManager {
 					createData: {
 						compilerOptions: this._defaults.getCompilerOptions(),
 						extraLibs: this._defaults.getExtraLibs(),
+						customTypeScriptPath: this._defaults.workerOptions.customTypeScriptPath,
 						customWorkerPath: this._defaults.workerOptions.customWorkerPath,
 						inlayHintsOptions: this._defaults.inlayHintsOptions
 					}


### PR DESCRIPTION
Allows configuring:
```ts
monaco.languages.typescript.typescriptDefaults.setWorkerOptions({
	customTypeScriptPath: 'https://someplace/typescript.js' // a file which will be loaded in the worker and which should define a global `ts` symbol
});
```
