### PR TITLE
opt example 

### DIFF
--- a/website/src/website/data/playground-samples/interacting-with-the-editor/adding-a-command-to-an-editor-instance/sample.js
+++ b/website/src/website/data/playground-samples/interacting-with-the-editor/adding-a-command-to-an-editor-instance/sample.js
@@ -28,7 +28,7 @@ editor.addCommand(
 	monaco.KeyCode.Tab,
 	function () {
 		// services available in `ctx`
-		alert("my command is executing!");
+		console.log("my command is executing!");
 	},
 	"myCondition1 && myCondition2"
 );
@@ -36,7 +36,7 @@ editor.addCommand(
 myCondition1.set(true);
 
 setTimeout(function () {
-	alert("now enabling also myCondition2, try pressing Tab!");
+	console.log("now enabling also myCondition2, try pressing Tab!");
 	myCondition2.set(true);
 	// you can use myCondition2.reset() to go back to the default
 }, 2000);


### PR DESCRIPTION
when use iframe and the 'allow-modals' keyword is not set, the `alert` function is not used .