### PR TITLE
feat: ATA support

### DIFF
--- a/build/importTypescript.ts
+++ b/build/importTypescript.ts
@@ -14,6 +14,7 @@ const generatedNote = `//
 `;
 
 const TYPESCRIPT_LIB_SOURCE = path.join(REPO_ROOT, 'node_modules/typescript/lib');
+const TYPESCRIPT_ATA_LIB_SOURCE = path.join(REPO_ROOT, 'node_modules/@typescript/ata/dist');
 const TYPESCRIPT_LIB_DESTINATION = path.join(REPO_ROOT, 'src/language/typescript/lib');
 
 (function () {
@@ -76,6 +77,11 @@ export var typescript = ts;
 		path.join(TYPESCRIPT_LIB_DESTINATION, 'typescriptServices.d.ts'),
 		generatedNote + dtsServices
 	);
+
+	let ata = fs.readFileSync(path.join(TYPESCRIPT_ATA_LIB_SOURCE, 'index.js')).toString();
+	fs.writeFileSync(path.join(TYPESCRIPT_LIB_DESTINATION, 'ata.js'), ata);
+	let ataDts = fs.readFileSync(path.join(TYPESCRIPT_ATA_LIB_SOURCE, 'index.d.ts')).toString();
+	fs.writeFileSync(path.join(TYPESCRIPT_LIB_DESTINATION, 'ata.d.ts'), ataDts);
 })();
 
 function importLibs() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 			"devDependencies": {
 				"@types/mocha": "^9.1.0",
 				"@types/shelljs": "^0.8.11",
+				"@typescript/ata": "^0.9.3",
 				"@typescript/vfs": "^1.3.5",
 				"chai": "^4.3.6",
 				"clean-css": "^5.2.4",
@@ -1850,6 +1851,15 @@
 			"optional": true,
 			"dependencies": {
 				"@types/node": "*"
+			}
+		},
+		"node_modules/@typescript/ata": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/@typescript/ata/-/ata-0.9.3.tgz",
+			"integrity": "sha512-/mETZakA5iOT8j8N8/ZUPLEsvSgMJz+cWt9Le1Q9dEwRXwDzekKXw3tpgrq77gaSxgE/Mn/nvtx8uzS41CmZKQ==",
+			"dev": true,
+			"peerDependencies": {
+				"typescript": "^4.4.4"
 			}
 		},
 		"node_modules/@typescript/vfs": {
@@ -8728,6 +8738,13 @@
 			"requires": {
 				"@types/node": "*"
 			}
+		},
+		"@typescript/ata": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/@typescript/ata/-/ata-0.9.3.tgz",
+			"integrity": "sha512-/mETZakA5iOT8j8N8/ZUPLEsvSgMJz+cWt9Le1Q9dEwRXwDzekKXw3tpgrq77gaSxgE/Mn/nvtx8uzS41CmZKQ==",
+			"dev": true,
+			"requires": {}
 		},
 		"@typescript/vfs": {
 			"version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 	"devDependencies": {
 		"@types/mocha": "^9.1.0",
 		"@types/shelljs": "^0.8.11",
+		"@typescript/ata": "^0.9.3",
 		"@typescript/vfs": "^1.3.5",
 		"chai": "^4.3.6",
 		"clean-css": "^5.2.4",
@@ -73,6 +74,9 @@
 		"vscode-uri": "3.0.3",
 		"webpack": "^5.76.0",
 		"yaserver": "^0.4.0"
+	},
+	"overrides": {
+		"typescript": "^5.0.2"
 	},
 	"alias": {
 		"process": false,

--- a/src/language/typescript/lib/ata.d.ts
+++ b/src/language/typescript/lib/ata.d.ts
@@ -1,0 +1,43 @@
+export interface ATABootstrapConfig {
+  /** A object you pass in to get callbacks */
+  delegate: {
+    /** The callback which gets called when ATA decides a file needs to be written to your VFS  */
+    receivedFile?: (code: string, path: string) => void
+    /** A way to display progress */
+    progress?: (downloaded: number, estimatedTotal: number) => void
+    /** Note: An error message does not mean ATA has stopped! */
+    errorMessage?: (userFacingMessage: string, error: Error) => void
+    /** A callback indicating that ATA actually has work to do */
+    started?: () => void
+    /** The callback when all ATA has finished */
+    finished?: (files: Map<string, string>) => void
+  }
+  /** Passed to fetch as the user-agent */
+  projectName: string
+  /** Your local copy of typescript */
+  typescript: typeof import("typescript")
+  /** If you need a custom version of fetch */
+  fetcher?: typeof fetch
+  /** If you need a custom logger instead of the console global */
+  logger?: Logger
+}
+
+type ModuleMeta = { state: "loading" }
+
+/**
+ * The function which starts up type acquisition,
+ * returns a function which you then pass the initial
+ * source code for the app with.
+ *
+ * This is effectively the main export, everything else is
+ * basically exported for tests and should be considered
+ * implementation details by consumers.
+ */
+export const setupTypeAcquisition: (config: ATABootstrapConfig) => (initialSourceFile: string) => void
+
+interface Logger {
+  log: (...args: any[]) => void
+  error: (...args: any[]) => void
+  groupCollapsed: (...args: any[]) => void
+  groupEnd: (...args: any[]) => void
+}

--- a/src/language/typescript/lib/ata.js
+++ b/src/language/typescript/lib/ata.js
@@ -1,0 +1,296 @@
+var __defProp = Object.defineProperty;
+var __defProps = Object.defineProperties;
+var __getOwnPropDescs = Object.getOwnPropertyDescriptors;
+var __getOwnPropSymbols = Object.getOwnPropertySymbols;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __propIsEnum = Object.prototype.propertyIsEnumerable;
+var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+var __spreadValues = (a, b) => {
+  for (var prop in b || (b = {}))
+    if (__hasOwnProp.call(b, prop))
+      __defNormalProp(a, prop, b[prop]);
+  if (__getOwnPropSymbols)
+    for (var prop of __getOwnPropSymbols(b)) {
+      if (__propIsEnum.call(b, prop))
+        __defNormalProp(a, prop, b[prop]);
+    }
+  return a;
+};
+var __spreadProps = (a, b) => __defProps(a, __getOwnPropDescs(b));
+var __async = (__this, __arguments, generator) => {
+  return new Promise((resolve, reject) => {
+    var fulfilled = (value) => {
+      try {
+        step(generator.next(value));
+      } catch (e) {
+        reject(e);
+      }
+    };
+    var rejected = (value) => {
+      try {
+        step(generator.throw(value));
+      } catch (e) {
+        reject(e);
+      }
+    };
+    var step = (x) => x.done ? resolve(x.value) : Promise.resolve(x.value).then(fulfilled, rejected);
+    step((generator = generator.apply(__this, __arguments)).next());
+  });
+};
+
+// src/apis.ts
+var getNPMVersionsForModule = (config, moduleName) => {
+  const url = `https://data.jsdelivr.com/v1/package/npm/${moduleName}`;
+  return api(config, url, { cache: "no-store" });
+};
+var getNPMVersionForModuleReference = (config, moduleName, reference) => {
+  const url = `https://data.jsdelivr.com/v1/package/resolve/npm/${moduleName}@${reference}`;
+  return api(config, url);
+};
+var getFiletreeForModuleWithVersion = (config, moduleName, version) => __async(void 0, null, function* () {
+  const url = `https://data.jsdelivr.com/v1/package/npm/${moduleName}@${version}/flat`;
+  const res = yield api(config, url);
+  if (res instanceof Error) {
+    return res;
+  } else {
+    return __spreadProps(__spreadValues({}, res), {
+      moduleName,
+      version
+    });
+  }
+});
+var getDTSFileForModuleWithVersion = (config, moduleName, version, file) => __async(void 0, null, function* () {
+  const url = `https://cdn.jsdelivr.net/npm/${moduleName}@${version}${file}`;
+  const f = config.fetcher || fetch;
+  const res = yield f(url);
+  if (res.ok) {
+    return res.text();
+  } else {
+    return new Error("OK");
+  }
+});
+function api(config, url, init) {
+  const f = config.fetcher || fetch;
+  return f(url, init).then((res) => {
+    if (res.ok) {
+      return res.json().then((f2) => f2);
+    } else {
+      return new Error("OK");
+    }
+  });
+}
+
+// src/edgeCases.ts
+var mapModuleNameToModule = (name) => {
+  const builtInNodeMods = [
+    "assert",
+    "assert/strict",
+    "async_hooks",
+    "buffer",
+    "child_process",
+    "cluster",
+    "console",
+    "constants",
+    "crypto",
+    "dgram",
+    "diagnostics_channel",
+    "dns",
+    "dns/promises",
+    "domain",
+    "events",
+    "fs",
+    "fs/promises",
+    "http",
+    "http2",
+    "https",
+    "inspector",
+    "module",
+    "net",
+    "os",
+    "path",
+    "path/posix",
+    "path/win32",
+    "perf_hooks",
+    "process",
+    "punycode",
+    "querystring",
+    "readline",
+    "repl",
+    "stream",
+    "stream/promises",
+    "stream/consumers",
+    "stream/web",
+    "string_decoder",
+    "sys",
+    "timers",
+    "timers/promises",
+    "tls",
+    "trace_events",
+    "tty",
+    "url",
+    "util",
+    "util/types",
+    "v8",
+    "vm",
+    "wasi",
+    "worker_threads",
+    "zlib"
+  ];
+  if (builtInNodeMods.includes(name.replace("node:", ""))) {
+    return "node";
+  }
+  return name;
+};
+
+// src/index.ts
+var setupTypeAcquisition = (config) => {
+  const moduleMap = new Map();
+  const fsMap = new Map();
+  let estimatedToDownload = 0;
+  let estimatedDownloaded = 0;
+  return (initialSourceFile) => {
+    estimatedToDownload = 0;
+    estimatedDownloaded = 0;
+    resolveDeps(initialSourceFile, 0).then((t) => {
+      var _a, _b;
+      if (estimatedDownloaded > 0) {
+        (_b = (_a = config.delegate).finished) == null ? void 0 : _b.call(_a, fsMap);
+      }
+    });
+  };
+  function resolveDeps(initialSourceFile, depth) {
+    return __async(this, null, function* () {
+      var _a, _b, _c, _d, _e;
+      const depsToGet = getNewDependencies(config, moduleMap, initialSourceFile);
+      depsToGet.forEach((dep) => moduleMap.set(dep.module, { state: "loading" }));
+      const trees = yield Promise.all(depsToGet.map((f) => getFileTreeForModuleWithTag(config, f.module, f.version)));
+      const treesOnly = trees.filter((t) => !("error" in t));
+      const hasDTS = treesOnly.filter((t) => t.files.find((f) => f.name.endsWith(".d.ts")));
+      const dtsFilesFromNPM = hasDTS.map((t) => treeToDTSFiles(t, `/node_modules/${t.moduleName}`));
+      const mightBeOnDT = treesOnly.filter((t) => !hasDTS.includes(t));
+      const dtTrees = yield Promise.all(mightBeOnDT.map((f) => getFileTreeForModuleWithTag(config, `@types/${getDTName(f.moduleName)}`, "latest")));
+      const dtTreesOnly = dtTrees.filter((t) => !("error" in t));
+      const dtsFilesFromDT = dtTreesOnly.map((t) => treeToDTSFiles(t, `/node_modules/@types/${getDTName(t.moduleName).replace("types__", "")}`));
+      const allDTSFiles = dtsFilesFromNPM.concat(dtsFilesFromDT).reduce((p, c) => p.concat(c), []);
+      estimatedToDownload += allDTSFiles.length;
+      if (allDTSFiles.length && depth === 0) {
+        (_b = (_a = config.delegate).started) == null ? void 0 : _b.call(_a);
+      }
+      for (const tree of treesOnly) {
+        let prefix = `/node_modules/${tree.moduleName}`;
+        if (dtTreesOnly.includes(tree))
+          prefix = `/node_modules/@types/${getDTName(tree.moduleName).replace("types__", "")}`;
+        const path = prefix + "/package.json";
+        const pkgJSON = yield getDTSFileForModuleWithVersion(config, tree.moduleName, tree.version, "/package.json");
+        if (typeof pkgJSON == "string") {
+          fsMap.set(path, pkgJSON);
+          (_d = (_c = config.delegate).receivedFile) == null ? void 0 : _d.call(_c, pkgJSON, path);
+        } else {
+          (_e = config.logger) == null ? void 0 : _e.error(`Could not download package.json for ${tree.moduleName}`);
+        }
+      }
+      yield Promise.all(allDTSFiles.map((dts) => __async(this, null, function* () {
+        var _a2, _b2, _c2;
+        const dtsCode = yield getDTSFileForModuleWithVersion(config, dts.moduleName, dts.moduleVersion, dts.path);
+        estimatedDownloaded++;
+        if (dtsCode instanceof Error) {
+          (_a2 = config.logger) == null ? void 0 : _a2.error(`Had an issue getting ${dts.path} for ${dts.moduleName}`);
+        } else {
+          fsMap.set(dts.vfsPath, dtsCode);
+          (_c2 = (_b2 = config.delegate).receivedFile) == null ? void 0 : _c2.call(_b2, dtsCode, dts.vfsPath);
+          if (config.delegate.progress && estimatedDownloaded % 5 === 0) {
+            config.delegate.progress(estimatedDownloaded, estimatedToDownload);
+          }
+          yield resolveDeps(dtsCode, depth + 1);
+        }
+      })));
+    });
+  }
+};
+function treeToDTSFiles(tree, vfsPrefix) {
+  const dtsRefs = [];
+  for (const file of tree.files) {
+    if (file.name.endsWith(".d.ts")) {
+      dtsRefs.push({
+        moduleName: tree.moduleName,
+        moduleVersion: tree.version,
+        vfsPath: `${vfsPrefix}${file.name}`,
+        path: file.name
+      });
+    }
+  }
+  return dtsRefs;
+}
+var getReferencesForModule = (ts, code) => {
+  const meta = ts.preProcessFile(code);
+  const libMap = ts.libMap || new Map();
+  const references = meta.referencedFiles.concat(meta.importedFiles).concat(meta.libReferenceDirectives).filter((f) => !f.fileName.endsWith(".d.ts")).filter((d) => !libMap.has(d.fileName));
+  return references.map((r) => {
+    let version = void 0;
+    if (!r.fileName.startsWith(".")) {
+      version = "latest";
+      const line = code.slice(r.end).split("\n")[0];
+      if (line.includes("// types:"))
+        version = line.split("// types: ")[1].trim();
+    }
+    return {
+      module: r.fileName,
+      version
+    };
+  });
+};
+function getNewDependencies(config, moduleMap, code) {
+  const refs = getReferencesForModule(config.typescript, code).map((ref) => __spreadProps(__spreadValues({}, ref), {
+    module: mapModuleNameToModule(ref.module)
+  }));
+  const modules = refs.filter((f) => !f.module.startsWith(".")).filter((m) => !moduleMap.has(m.module));
+  return modules;
+}
+var getFileTreeForModuleWithTag = (config, moduleName, tag) => __async(void 0, null, function* () {
+  let toDownload = tag || "latest";
+  if (toDownload.split(".").length < 2) {
+    const response = yield getNPMVersionForModuleReference(config, moduleName, toDownload);
+    if (response instanceof Error) {
+      return {
+        error: response,
+        userFacingMessage: `Could not go from a tag to version on npm for ${moduleName} - possible typo?`
+      };
+    }
+    const neededVersion = response.version;
+    if (!neededVersion) {
+      const versions = yield getNPMVersionsForModule(config, moduleName);
+      if (versions instanceof Error) {
+        return {
+          error: response,
+          userFacingMessage: `Could not get versions on npm for ${moduleName} - possible typo?`
+        };
+      }
+      const tags = Object.entries(versions.tags).join(", ");
+      return {
+        error: new Error("Could not find tag for module"),
+        userFacingMessage: `Could not find a tag for ${moduleName} called ${tag}. Did find ${tags}`
+      };
+    }
+    toDownload = neededVersion;
+  }
+  const res = yield getFiletreeForModuleWithVersion(config, moduleName, toDownload);
+  if (res instanceof Error) {
+    return {
+      error: res,
+      userFacingMessage: `Could not get the files for ${moduleName}@${toDownload}. Is it possibly a typo?`
+    };
+  }
+  return res;
+});
+function getDTName(s) {
+  if (s.indexOf("@") === 0 && s.indexOf("/") !== -1) {
+    s = s.substr(1).replace("/", "__");
+  }
+  return s;
+}
+export {
+  getFileTreeForModuleWithTag,
+  getNewDependencies,
+  getReferencesForModule,
+  setupTypeAcquisition
+};

--- a/src/language/typescript/monaco.contribution.ts
+++ b/src/language/typescript/monaco.contribution.ts
@@ -178,6 +178,13 @@ interface InlayHintsOptions {
 	readonly includeInlayEnumMemberValueHints?: boolean;
 }
 
+export interface AtaOptions {
+	/** Enable ATA */
+	enabled: boolean;
+	/** User-Agent when requesting to jsdelivr */
+	userAgent: string;
+}
+
 interface IExtraLib {
 	content: string;
 	version: number;
@@ -308,6 +315,8 @@ export interface LanguageServiceDefaults {
 
 	readonly inlayHintsOptions: InlayHintsOptions;
 
+	readonly ataOptions: AtaOptions;
+
 	readonly modeConfiguration: ModeConfiguration;
 	setModeConfiguration(modeConfiguration: ModeConfiguration): void;
 
@@ -383,6 +392,12 @@ export interface LanguageServiceDefaults {
 	 * Configure inlay hints options.
 	 */
 	setInlayHintsOptions(options: InlayHintsOptions): void;
+
+	/**
+	 * Configure ATA(Automatic Type Acquisition)
+	 * ATA fetches type definition from jsdelivr CDN
+	 */
+	setAtaOptions(options: AtaOptions): void;
 }
 
 export interface TypeScriptWorker {
@@ -559,6 +574,7 @@ class LanguageServiceDefaultsImpl implements LanguageServiceDefaults {
 	private _onDidExtraLibsChangeTimeout: number;
 	private _inlayHintsOptions!: InlayHintsOptions;
 	private _modeConfiguration!: ModeConfiguration;
+	private _ataOptions: AtaOptions;
 
 	constructor(
 		compilerOptions: CompilerOptions,
@@ -570,6 +586,7 @@ class LanguageServiceDefaultsImpl implements LanguageServiceDefaults {
 		this._extraLibs = Object.create(null);
 		this._removedExtraLibs = Object.create(null);
 		this._eagerModelSync = false;
+		this._ataOptions = Object.create(null);
 		this.setCompilerOptions(compilerOptions);
 		this.setDiagnosticsOptions(diagnosticsOptions);
 		this.setWorkerOptions(workerOptions);
@@ -596,6 +613,10 @@ class LanguageServiceDefaultsImpl implements LanguageServiceDefaults {
 
 	get inlayHintsOptions(): InlayHintsOptions {
 		return this._inlayHintsOptions;
+	}
+
+	get ataOptions(): AtaOptions {
+		return this._ataOptions;
 	}
 
 	getExtraLibs(): IExtraLibs {
@@ -727,6 +748,15 @@ class LanguageServiceDefaultsImpl implements LanguageServiceDefaults {
 
 	setModeConfiguration(modeConfiguration: ModeConfiguration): void {
 		this._modeConfiguration = modeConfiguration || Object.create(null);
+		this._onDidChange.fire(undefined);
+	}
+
+	getAtaOptions() {
+		return this._ataOptions;
+	}
+
+	setAtaOptions(options: AtaOptions) {
+		this._ataOptions = options || Object.create(null);
 		this._onDidChange.fire(undefined);
 	}
 }

--- a/src/language/typescript/workerManager.ts
+++ b/src/language/typescript/workerManager.ts
@@ -71,7 +71,8 @@ export class WorkerManager {
 						compilerOptions: this._defaults.getCompilerOptions(),
 						extraLibs: this._defaults.getExtraLibs(),
 						customWorkerPath: this._defaults.workerOptions.customWorkerPath,
-						inlayHintsOptions: this._defaults.inlayHintsOptions
+						inlayHintsOptions: this._defaults.inlayHintsOptions,
+						ataOptions: this._defaults.ataOptions
 					}
 				});
 

--- a/website/src/website/data/playground-samples/extending-language-services/configure-javascript-defaults/sample.js
+++ b/website/src/website/data/playground-samples/extending-language-services/configure-javascript-defaults/sample.js
@@ -30,8 +30,16 @@ monaco.languages.typescript.javascriptDefaults.addExtraLib(libSource, libUri);
 // Creating a model for the library allows "peek definition/references" commands to work with the library.
 monaco.editor.createModel(libSource, "typescript", monaco.Uri.parse(libUri));
 
+// Enable ATA(Automatic Type Acquisition)
+monaco.languages.typescript.javascriptDefaults.setAtaOptions({
+	enabled: true,
+	userAgent: "Monaco Editor Playground",
+});
+
 var jsCode = [
 	'"use strict";',
+	"",
+	'import * as fs from "fs"; // ATA tries to get type definition of fs',
 	"",
 	"class Chuck {",
 	"    greet() {",

--- a/website/webpack.config.ts
+++ b/website/webpack.config.ts
@@ -39,6 +39,11 @@ module.exports = {
 		},
 		allowedHosts: "all",
 		watchFiles: [],
+		client: {
+			overlay: {
+				warnings: false,
+			},
+		},
 	},
 	module: {
 		rules: [
@@ -132,7 +137,10 @@ module.exports = {
 			],
 		}),
 		new CopyPlugin({
-			patterns: [{ from: "../out/languages/", to: "./out/languages/" }],
+			patterns: [
+				{ from: "../out/languages/", to: "./out/languages/" },
+				{ from: "../out/monaco-editor/", to: "./out/monaco-editor/" },
+			],
 		}),
 	],
 } as webpack.Configuration;


### PR DESCRIPTION
I added ATA(Automatic Type Acquisition) feature using `@typescript/ata`(https://github.com/microsoft/TypeScript-Website/tree/v2/packages/ata).

* default is disabled, so there is no downgrades.
* fetch type definition from jsdelivr.
* fetch is called in web worker.
  * this is because monaco.contribution.ts does not contains ts namespace and is keeping small size.
  * but web worker does not know when code is updated, so ATA runs in getScriptText method asynchronously.

I don't know the best way to run locally Monaco Editor Website but I used below config.

```json
{
    "loaderUrl": "http://localhost:8080/node_modules/monaco-editor-core/dev/vs/loader.js",
    "loaderConfigPaths": {
        "vs": "http://localhost:8080/node_modules/monaco-editor-core/dev/vs",
        "vs/fillers/monaco-editor-core": "http://localhost:8080/out/languages/amd-tsc/fillers/monaco-editor-core-amd",
        "vs/language": "http://localhost:8080/out/languages/amd-tsc/language",
        "vs/basic-language": "http://localhost:8080/out/languages/amd-tsc/basic-language"
    },
    "codiconUrl": "http://localhost:8080/node_modules/monaco-editor-core/dev/vs/base/browser/ui/codicons/codicon/codicon.ttf",
    "monacoTypesUrl": "http://localhost:8080/out/monaco-editor/monaco.d.ts"
}
```