### PR TITLE
Include .xsd and .xslt as an XML extension

### DIFF
--- a/src/basic-languages/xml/xml.contribution.ts
+++ b/src/basic-languages/xml/xml.contribution.ts
@@ -12,6 +12,7 @@ registerLanguage({
 	id: 'xml',
 	extensions: [
 		'.xml',
+		'.xsd',
 		'.dtd',
 		'.ascx',
 		'.csproj',
@@ -25,6 +26,7 @@ registerLanguage({
 		'.svg',
 		'.svgz',
 		'.opf',
+		'.xslt',
 		'.xsl'
 	],
 	firstLine: '(\\<\\?xml.*)|(\\<svg)|(\\<\\!doctype\\s+svg)',


### PR DESCRIPTION
Fixes #3865.

Not sure what the policy on extensions is. There is `.csproj` but not `.vbproj` or any other `.*proj`. Other reasonable candidates might be `.*manifest` and `.*config`.