### PR TITLE
Avoid a hack in the WGSL lexer

### DIFF
--- a/src/basic-languages/wgsl/wgsl.ts
+++ b/src/basic-languages/wgsl/wgsl.ts
@@ -377,7 +377,7 @@ export const language = <languages.IMonarchLanguage>{
 	predeclared_intrinsics,
 	operators,
 
-	symbols: /[!%&*+\-\.\/:;<=>^|_~]+/,
+	symbols: /[!%&*+\-\.\/:;<=>^|_~,]+/,
 
 	tokenizer: {
 		root: [
@@ -402,8 +402,6 @@ export const language = <languages.IMonarchLanguage>{
 			{ include: '@commentOrSpace' },
 			{ include: '@numbers' },
 
-			[/;:\./, 'delimiter'],
-			[/,/, 'delimiter'], // Hack: Should be in previous rule
 			[/[{}()\[\]]/, '@brackets'],
 			['@', 'annotation', '@attribute'],
 			[


### PR DESCRIPTION
This is a non-functioal change.

The current rule for delimiters was silly: it should have been a character class range (e.g. [ ... ]).

Move delimiter handling into the symbols matcher.