### PR TITLE
Fix reference error in convert method of OutlineAdapter

### DIFF
--- a/src/language/typescript/languageFeatures.ts
+++ b/src/language/typescript/languageFeatures.ts
@@ -890,7 +890,7 @@ export class OutlineAdapter extends Adapter implements languages.DocumentSymbolP
 				range: this._textSpanToRange(model, item.spans[0]),
 				selectionRange: this._textSpanToRange(model, item.spans[0]),
 				tags: [],
-				children: item.childItems?.map((child) => convert(child, result.name)),
+				children: item.childItems?.map((child) => convert(child, item.text)),
 				containerName: containerLabel
 			};
 			return result;


### PR DESCRIPTION
As the result object is about to be created, it can not be referred to when mapping child items.

This fixes #3923