### PR TITLE
[Webpack Plugin] Fix CJS being injected in ESM files

### DIFF
--- a/webpack-plugin/src/loaders/include.ts
+++ b/webpack-plugin/src/loaders/include.ts
@@ -30,8 +30,12 @@ export const pitch: PitchLoaderDefinitionFunction<ILoaderOptions> = function pit
 		...(globals
 			? Object.keys(globals).map((key) => `self[${JSON.stringify(key)}] = ${globals[key]};`)
 			: []),
-		...pre.map((include: any) => `require(${stringifyRequest(include)});`),
-		`module.exports = require(${stringifyRequest(`!!${remainingRequest}`)});`,
-		...post.map((include: any) => `require(${stringifyRequest(include)});`)
+		...pre.map((include: any) => `import ${stringifyRequest(include)};`),
+		`
+import * as monaco from ${stringifyRequest(`!!${remainingRequest}`)};
+export * from ${stringifyRequest(`!!${remainingRequest}`)};
+export default monaco;
+		`,
+		...post.map((include: any) => `import ${stringifyRequest(include)};`)
 	].join('\n');
 };


### PR DESCRIPTION
I replaced the CJS `require` and `module.exports` with `import` and `export` statements. 

This PR should fix #2735.

Tests are ok on my dev environment. 