### PR TITLE
Extend the "Rendering Glyphs In The Margin" example to include a transparent color note.

### DIFF
--- a/website/src/website/data/playground-samples/interacting-with-the-editor/rendering-glyphs-in-the-margin/sample.css
+++ b/website/src/website/data/playground-samples/interacting-with-the-editor/rendering-glyphs-in-the-margin/sample.css
@@ -2,5 +2,6 @@
 	background: red;
 }
 .myContentClass {
-	background: lightblue;
+	/* Make sure to use transparent colors for the selection to work */
+	background: rgba(173, 216, 230, 0.5);
 }


### PR DESCRIPTION
Following up on https://github.com/microsoft/monaco-editor/issues/3929. It might be helpful to include recommended solution in the example. Otherwise demo example looks broken as selection is not working as expected.

After

https://user-images.githubusercontent.com/963490/236619213-78b24ed2-8b7c-4aea-96d6-0b858975f653.mov

Before

https://user-images.githubusercontent.com/963490/233871151-11bd5f67-4726-414f-9629-9c154a001c05.mov




