### PR TITLE
Add more xml and javascript mime types

### DIFF
--- a/src/basic-languages/javascript/javascript.contribution.ts
+++ b/src/basic-languages/javascript/javascript.contribution.ts
@@ -14,7 +14,7 @@ registerLanguage({
 	firstLine: '^#!.*\\bnode',
 	filenames: ['jakefile'],
 	aliases: ['JavaScript', 'javascript', 'js'],
-	mimetypes: ['text/javascript'],
+	mimetypes: ['text/javascript', 'application/javascript', 'application/x-javascript'],
 	loader: () => {
 		if (AMD) {
 			return new Promise((resolve, reject) => {

--- a/src/basic-languages/xml/xml.contribution.ts
+++ b/src/basic-languages/xml/xml.contribution.ts
@@ -31,7 +31,7 @@ registerLanguage({
 	],
 	firstLine: '(\\<\\?xml.*)|(\\<svg)|(\\<\\!doctype\\s+svg)',
 	aliases: ['XML', 'xml'],
-	mimetypes: ['text/xml', 'application/xml', 'application/xaml+xml', 'application/xml-dtd'],
+	mimetypes: ['text/xml', 'application/xml', 'application/xaml+xml', 'application/xml-dtd', 'application/xhtml+xml', 'image/svg+xml'],
 	loader: () => {
 		if (AMD) {
 			return new Promise((resolve, reject) => {


### PR DESCRIPTION
I'm currently working around this via:

```js
const javascriptLangConfig = monaco.languages.getLanguages()[monaco.languages.getEncodedLanguageId('javascript') - 1];
const xmlLangConfig = monaco.languages.getLanguages()[monaco.languages.getEncodedLanguageId('xml') - 1];

// These are commonly used content-types headers we want to work for syntax highlighting.
javascriptLangConfig.mimetypes.push('application/javascript', 'application/x-javascript');
xmlLangConfig.mimetypes.push('image/svg+xml', 'application/xhtml+xml');
```

It won't hurt having them in Monaco?