### PR TITLE
Add `customWorkerFactory` to customize tsworker directly

### DIFF
--- a/src/language/typescript/monaco.contribution.ts
+++ b/src/language/typescript/monaco.contribution.ts
@@ -6,6 +6,7 @@
 import type * as mode from './tsMode';
 import { typescriptVersion as tsversion } from './lib/typescriptServicesMetadata'; // do not import the whole typescriptServices here
 import { languages, Emitter, IEvent, IDisposable, Uri } from '../../fillers/monaco-editor-core';
+import { CustomTSWebWorkerFactory } from './tsWorker';
 
 //#region enums copied from typescript to prevent loading the entire typescriptServices ---
 
@@ -166,6 +167,7 @@ export interface DiagnosticsOptions {
 export interface WorkerOptions {
 	/** A full HTTP path to a JavaScript file which adds a function `customTSWorkerFactory` to the self inside a web-worker */
 	customWorkerPath?: string;
+	customWorkerFactory?: CustomTSWebWorkerFactory;
 }
 
 interface InlayHintsOptions {

--- a/src/language/typescript/tsWorker.ts
+++ b/src/language/typescript/tsWorker.ts
@@ -463,6 +463,7 @@ export interface ICreateData {
 	compilerOptions: ts.CompilerOptions;
 	extraLibs: IExtraLibs;
 	customWorkerPath?: string;
+	customWorkerFactory?: CustomTSWebWorkerFactory;
 	inlayHintsOptions?: ts.UserPreferences;
 }
 
@@ -497,9 +498,11 @@ export function create(ctx: worker.IWorkerContext, createData: ICreateData): Typ
 				);
 			}
 
-			TSWorkerClass = workerFactoryFunc(TypeScriptWorker, ts, libFileMap);
+			TSWorkerClass = workerFactoryFunc(TSWorkerClass, ts, libFileMap);
 		}
 	}
+	if (createData.customWorkerFactory)
+		TSWorkerClass = createData.customWorkerFactory(TSWorkerClass, ts, libFileMap);
 
 	return new TSWorkerClass(ctx, createData);
 }

--- a/src/language/typescript/workerManager.ts
+++ b/src/language/typescript/workerManager.ts
@@ -71,6 +71,7 @@ export class WorkerManager {
 						compilerOptions: this._defaults.getCompilerOptions(),
 						extraLibs: this._defaults.getExtraLibs(),
 						customWorkerPath: this._defaults.workerOptions.customWorkerPath,
+						customWorkerFactory: this._defaults.workerOptions.customWorkerFactory,
 						inlayHintsOptions: this._defaults.inlayHintsOptions
 					}
 				});


### PR DESCRIPTION
Add a way to customize typescript worker in module workers, avoiding importScripts (which the customWorkerPath uses to extend the typescript worker).

Hoping to provide some progress to https://github.com/microsoft/monaco-editor/issues/3151.