### PR TITLE
Elixir - Add support for multi-letter uppercase sigils

### DIFF
--- a/src/basic-languages/elixir/elixir.test.ts
+++ b/src/basic-languages/elixir/elixir.test.ts
@@ -303,6 +303,17 @@ testTokenization('elixir', [
 			]
 		}
 	],
+	// Sigils (multi-letter uppercase)
+	[
+		{
+			line: '~DX/foo/',
+			tokens: [
+				{ startIndex: 0, type: 'sigil.delimiter.elixir' },
+				{ startIndex: 4, type: 'sigil.elixir' },
+				{ startIndex: 7, type: 'sigil.delimiter.elixir' }
+			]
+		}
+	],
 	// Sigils (no interpolation)
 	[
 		{
@@ -314,6 +325,17 @@ testTokenization('elixir', [
 			]
 		}
 	],
+	// Sigils (multi-letter uppercase no interpolation)
+	[
+		{
+			line: '~WW/foo#{1}/',
+			tokens: [
+				{ startIndex: 0, type: 'sigil.delimiter.elixir' },
+				{ startIndex: 4, type: 'sigil.elixir' },
+				{ startIndex: 11, type: 'sigil.delimiter.elixir' }
+			]
+		}
+	],
 	// Sigils (modifiers)
 	[
 		{
@@ -322,6 +344,17 @@ testTokenization('elixir', [
 				{ startIndex: 0, type: 'sigil.delimiter.elixir' },
 				{ startIndex: 3, type: 'sigil.elixir' },
 				{ startIndex: 9, type: 'sigil.delimiter.elixir' }
+			]
+		}
+	],
+	// Sigils (multi-letter uppercase with modifiers)
+	[
+		{
+			line: '~DX/custom/az09',
+			tokens: [
+				{ startIndex: 0, type: 'sigil.delimiter.elixir' },
+				{ startIndex: 4, type: 'sigil.elixir' },
+				{ startIndex: 10, type: 'sigil.delimiter.elixir' }
 			]
 		}
 	],

--- a/src/basic-languages/elixir/elixir.ts
+++ b/src/basic-languages/elixir/elixir.ts
@@ -333,7 +333,8 @@ export const language = <languages.IMonarchLanguage>{
 
 		// See https://elixir-lang.org/getting-started/sigils.html
 		// Sigils allow for typing values using their textual representation.
-		// All sigils start with ~ followed by a letter indicating sigil type
+		// All sigils start with ~ followed by a letter or
+		// multi-letter uppercase starting at Elixir v1.15.0, indicating sigil type
 		// and then a delimiter pair enclosing the textual representation.
 		// Optional modifiers are allowed after the closing delimiter.
 		// For instance a regular expressions can be written as:
@@ -353,16 +354,16 @@ export const language = <languages.IMonarchLanguage>{
 
 		sigils: [
 			[/~[a-z]@sigilStartDelimiter/, { token: '@rematch', next: '@sigil.interpol' }],
-			[/~[A-Z]@sigilStartDelimiter/, { token: '@rematch', next: '@sigil.noInterpol' }]
+			[/~([A-Z]+)@sigilStartDelimiter/, { token: '@rematch', next: '@sigil.noInterpol' }]
 		],
 
 		sigil: [
-			[/~([a-zA-Z])\{/, { token: '@rematch', switchTo: '@sigilStart.$S2.$1.{.}' }],
-			[/~([a-zA-Z])\[/, { token: '@rematch', switchTo: '@sigilStart.$S2.$1.[.]' }],
-			[/~([a-zA-Z])\(/, { token: '@rematch', switchTo: '@sigilStart.$S2.$1.(.)' }],
-			[/~([a-zA-Z])\</, { token: '@rematch', switchTo: '@sigilStart.$S2.$1.<.>' }],
+			[/~([a-z]|[A-Z]+)\{/, { token: '@rematch', switchTo: '@sigilStart.$S2.$1.{.}' }],
+			[/~([a-z]|[A-Z]+)\[/, { token: '@rematch', switchTo: '@sigilStart.$S2.$1.[.]' }],
+			[/~([a-z]|[A-Z]+)\(/, { token: '@rematch', switchTo: '@sigilStart.$S2.$1.(.)' }],
+			[/~([a-z]|[A-Z]+)\</, { token: '@rematch', switchTo: '@sigilStart.$S2.$1.<.>' }],
 			[
-				/~([a-zA-Z])(@sigilSymmetricDelimiter)/,
+				/~([a-z]|[A-Z]+)(@sigilSymmetricDelimiter)/,
 				{ token: '@rematch', switchTo: '@sigilStart.$S2.$1.$2.$2' }
 			]
 		],
@@ -475,7 +476,7 @@ export const language = <languages.IMonarchLanguage>{
 		// Fallback to the generic sigil by default
 		'sigilStart.interpol': [
 			[
-				/~([a-zA-Z])@sigilStartDelimiter/,
+				/~([a-z]|[A-Z]+)@sigilStartDelimiter/,
 				{
 					token: 'sigil.delimiter',
 					switchTo: '@sigilContinue.$S2.$S3.$S4.$S5'
@@ -498,7 +499,7 @@ export const language = <languages.IMonarchLanguage>{
 
 		'sigilStart.noInterpol': [
 			[
-				/~([a-zA-Z])@sigilStartDelimiter/,
+				/~([a-z]|[A-Z]+)@sigilStartDelimiter/,
 				{
 					token: 'sigil.delimiter',
 					switchTo: '@sigilContinue.$S2.$S3.$S4.$S5'


### PR DESCRIPTION
Elixir v1.15.0 has added support for multi-letter uppercase sigils, eg:

```elixir
~LVN/content/
~LVN/content/m
```

Previously only a single letter was supported so these changes keep backwards compatibility.

### Refs
Proposal: https://groups.google.com/g/elixir-lang-core/c/cocMcghahs4/m/DdYRNfuYAwAJ
PR: https://github.com/elixir-lang/elixir/pull/12448
Release notes: https://github.com/elixir-lang/elixir/releases/tag/v1.15.0