### PR TITLE
Throw if inlay hint text is not a string

### DIFF
--- a/src/language/typescript/languageFeatures.ts
+++ b/src/language/typescript/languageFeatures.ts
@@ -1246,6 +1246,9 @@ export class InlayHintsAdapter extends Adapter implements languages.InlayHintsPr
 
 		const tsHints = await worker.provideInlayHints(fileName, start, end);
 		const hints: languages.InlayHint[] = tsHints.map((hint) => {
+			if (typeof hint.text !== 'string') {
+				throw new Error('hint.text may only be a string');
+			}
 			return {
 				...hint,
 				label: hint.text,


### PR DESCRIPTION
After https://github.com/microsoft/TypeScript/pull/54734, the inlay hint text may be an array if `interactiveInlayHints` is set. The array would need to be transformed from the TS protocol into the VS Code / monaco protocols (converting locations / offsets / URIs / etc), but that's not done here (yet?), and so causes a compiler error in our pipelines that build the nightly / PR playground.

This change works around the problem by asserting that the text prop is a string, which should always be the case in monaco (for now) as `interactiveInlayHints` is not enabled.

This code is safe for existing versions of TS before 5.2; the check will just be a noop.

Marking as a draft pending a discussion as to if the API we have merged is the "final" one, or if we think it'd be better to just use another prop and then set `text: ""` or something.