### PR TITLE
Remove 2 java-only operators from c++ tokenizer

### DIFF
--- a/src/basic-languages/cpp/cpp.ts
+++ b/src/basic-languages/cpp/cpp.ts
@@ -259,7 +259,6 @@ export const language = <languages.IMonarchLanguage>{
 		'%',
 		'<<',
 		'>>',
-		'>>>',
 		'+=',
 		'-=',
 		'*=',
@@ -269,8 +268,7 @@ export const language = <languages.IMonarchLanguage>{
 		'^=',
 		'%=',
 		'<<=',
-		'>>=',
-		'>>>='
+		'>>='
 	],
 
 	// we include these common regular expressions


### PR DESCRIPTION
cpp has no `>>>`, I'm guessing it's a leftover from somewhere else.