### PR TITLE
Fix suggestion for #4253

### DIFF
--- a/src/basic-languages/cpp/cpp.ts
+++ b/src/basic-languages/cpp/cpp.ts
@@ -312,8 +312,7 @@ export const language = <languages.IMonarchLanguage>{
 			// [[ attributes ]].
 			[/\[\s*\[/, { token: 'annotation', next: '@annotation' }],
 			// delimiters and operators
-			[/[{}()\[\]]/, '@brackets'],
-			[/[<>](?!@symbols)/, '@brackets'],
+			[/[{}()<>\[\]]/, '@brackets'],
 			[
 				/@symbols/,
 				{


### PR DESCRIPTION
In the cpp tokenizer, angled brackets (`<>`) were separated from other brackets to hold an additional post-condition:

```js
...
	[/[{}()\[\]]/, '@brackets'],
	[/[<>](?!@symbols)/, '@brackets'],    // <----
```

Not sure why, one guessed motivation is that a tokenizer needs to be extra careful with `<` since it might eventually resolve to the operator `<<`. However, 

(1) this doesn't solve it, `<<` is still not tokenized to an operator (it fails all tokenizer regexes), 

(2) this extra-liberal exclusion causes bugs like #4253.

This suggested fix treats angled-brackets identically to other brackets. A true c++-conforming tokenizer might require `@rematch` and other heavy machinery, but this one is pretty certain to be at least some step forward.
