### PR TITLE
Remove explicit consideration as using|alignas as keywords within a C++ annotation

### DIFF
--- a/src/basic-languages/cpp/cpp.ts
+++ b/src/basic-languages/cpp/cpp.ts
@@ -400,7 +400,6 @@ export const language = <languages.IMonarchLanguage>{
 
 		annotation: [
 			{ include: '@whitespace' },
-			[/using|alignas/, 'keyword'],
 			[/[a-zA-Z0-9_]+/, 'annotation'],
 			[/[,:]/, 'delimiter'],
 			[/[()]/, '@brackets'],


### PR DESCRIPTION
`using` indeed has syntactic meaning within a c++ attribute, but so do `likely`, `deprecated`, `always_inline` and countless others. 
This deletion makes the behavior consistent, and avoids bugs like #3395.