### PR TITLE
Expose JSON worker

### DIFF
--- a/src/language/json/jsonMode.ts
+++ b/src/language/json/jsonMode.ts
@@ -10,6 +10,18 @@ import * as languageFeatures from '../common/lspLanguageFeatures';
 import { createTokenizationSupport } from './tokenization';
 import { Uri, IDisposable, languages, editor } from '../../fillers/monaco-editor-core';
 
+let worker: languageFeatures.WorkerAccessor<JSONWorker>;
+
+export function getWorker(): Promise<(...uris: Uri[]) => Promise<JSONWorker>> {
+	return new Promise((resolve, reject) => {
+		if (!worker) {
+			return reject('JSON not registered!');
+		}
+
+		resolve(worker);
+	});
+}
+
 class JSONDiagnosticsAdapter extends languageFeatures.DiagnosticsAdapter<JSONWorker> {
 	constructor(
 		languageId: string,
@@ -44,9 +56,7 @@ export function setupMode(defaults: LanguageServiceDefaults): IDisposable {
 	const client = new WorkerManager(defaults);
 	disposables.push(client);
 
-	const worker: languageFeatures.WorkerAccessor<JSONWorker> = (
-		...uris: Uri[]
-	): Promise<JSONWorker> => {
+	worker = (...uris: Uri[]): Promise<JSONWorker> => {
 		return client.getLanguageServiceWorker(...uris);
 	};
 

--- a/src/language/json/jsonWorker.ts
+++ b/src/language/json/jsonWorker.ts
@@ -144,6 +144,22 @@ export class JSONWorker {
 		let ranges = this._languageService.getSelectionRanges(document, positions, jsonDocument);
 		return Promise.resolve(ranges);
 	}
+	async parseJSONDocument(uri: string): Promise<jsonService.JSONDocument | null> {
+		let document = this._getTextDocument(uri);
+		if (!document) {
+			return null;
+		}
+		let jsonDocument = this._languageService.parseJSONDocument(document);
+		return Promise.resolve(jsonDocument);
+	}
+	async getMatchingSchemas(uri: string): Promise<jsonService.MatchingSchema[]> {
+		let document = this._getTextDocument(uri);
+		if (!document) {
+			return [];
+		}
+		let jsonDocument = this._languageService.parseJSONDocument(document);
+		return Promise.resolve(this._languageService.getMatchingSchemas(document, jsonDocument));
+	}
 	private _getTextDocument(uri: string): jsonService.TextDocument | null {
 		let models = this._ctx.getMirrorModels();
 		for (let model of models) {

--- a/src/language/json/monaco.contribution.ts
+++ b/src/language/json/monaco.contribution.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as mode from './jsonMode';
-import { Emitter, IEvent, languages } from '../../fillers/monaco-editor-core';
+import { Emitter, IEvent, languages, Uri } from '../../fillers/monaco-editor-core';
+import type { JSONWorker } from './jsonWorker';
 
 // --- JSON configuration and defaults ---------
 
@@ -197,8 +198,12 @@ export const jsonDefaults: LanguageServiceDefaults = new LanguageServiceDefaults
 	modeConfigurationDefault
 );
 
+export const getWorker = (): Promise<(...uris: Uri[]) => Promise<JSONWorker>> => {
+	return getMode().then((mode) => mode.getWorker());
+};
+
 // export to the global based API
-(<any>languages).json = { jsonDefaults };
+(<any>languages).json = { jsonDefaults, getWorker };
 
 // --- Registration to monaco editor ---
 

--- a/src/language/json/monaco.contribution.ts
+++ b/src/language/json/monaco.contribution.ts
@@ -7,69 +7,6 @@ import * as mode from './jsonMode';
 import { Emitter, IEvent, languages, Uri } from 'monaco-editor-core';
 
 // ---- JSON service types ----
-/**
- * Defines a decimal number. Since decimal numbers are very
- * rare in the language server specification we denote the
- * exact range with every decimal using the mathematics
- * interval notations (e.g. [0, 1] denotes all decimals d with
- * 0 <= d <= 1.
- */
-export type decimal = number;
-
-/**
- * Defines an unsigned integer in the range of 0 to 2^31 - 1.
- */
-export type uinteger = number;
-
-/**
- * Position in a text document expressed as zero-based line and character offset.
- * The offsets are based on a UTF-16 string representation. So a string of the form
- * `a𐐀b` the character offset of the character `a` is 0, the character offset of `𐐀`
- * is 1 and the character offset of b is 3 since `𐐀` is represented using two code
- * units in UTF-16.
- *
- * Positions are line end character agnostic. So you can not specify a position that
- * denotes `\r|\n` or `\n|` where `|` represents the character offset.
- */
-export interface Position {
-	/**
-	 * Line position in a document (zero-based).
-	 */
-	line: uinteger;
-	/**
-	 * Character offset on a line in a document (zero-based). Assuming that the line is
-	 * represented as a string, the `character` value represents the gap between the
-	 * `character` and `character + 1`.
-	 *
-	 * If the character value is greater than the line length it defaults back to the
-	 * line length.
-	 */
-	character: uinteger;
-}
-
-/**
- * A range in a text document expressed as (zero-based) start and end positions.
- *
- * If you want to specify a range that contains a line including the line ending
- * character(s) then use an end position denoting the start of the next line.
- * For example:
- * ```ts
- * {
- *     start: { line: 5, character: 23 }
- *     end : { line 6, character : 0 }
- * }
- * ```
- */
-export interface Range {
-	/**
-	 * The range's start position
-	 */
-	start: Position;
-	/**
-	 * The range's end position.
-	 */
-	end: Position;
-}
 export interface BaseASTNode {
 	readonly type: 'object' | 'array' | 'property' | 'string' | 'number' | 'boolean' | 'null';
 	readonly parent?: ASTNode;
@@ -206,21 +143,8 @@ export interface MatchingSchema {
 	node: ASTNode;
 	schema: JSONSchema;
 }
-/**
- * A tagging type for string properties that are actually document URIs.
- */
-export type DocumentUri = string;
 
-/**
- * Represents a location inside a resource, such as a line
- * inside a text file.
- */
-export interface Location {
-	uri: DocumentUri;
-	range: Range;
-}
 // --- JSON configuration and defaults ---------
-
 export interface DiagnosticsOptions {
 	/**
 	 * If set, the validator will be enabled and perform syntax and schema based validation,

--- a/src/language/json/monaco.contribution.ts
+++ b/src/language/json/monaco.contribution.ts
@@ -17,28 +17,6 @@ import { Emitter, IEvent, languages, Uri } from 'monaco-editor-core';
 export type decimal = number;
 
 /**
- * Represents a color in RGBA space.
- */
-export interface Color {
-	/**
-	 * The red component of this color in the range [0-1].
-	 */
-	readonly red: decimal;
-	/**
-	 * The green component of this color in the range [0-1].
-	 */
-	readonly green: decimal;
-	/**
-	 * The blue component of this color in the range [0-1].
-	 */
-	readonly blue: decimal;
-	/**
-	 * The alpha component of this color in the range [0-1].
-	 */
-	readonly alpha: decimal;
-}
-
-/**
  * Defines an unsigned integer in the range of 0 to 2^31 - 1.
  */
 export type uinteger = number;
@@ -92,74 +70,6 @@ export interface Range {
 	 */
 	end: Position;
 }
-
-/**
- * A text edit applicable to a text document.
- */
-export interface TextEdit {
-	/**
-	 * The range of the text document to be manipulated. To insert
-	 * text into a document create a range where start === end.
-	 */
-	range: Range;
-	/**
-	 * The string to be inserted. For delete operations use an
-	 * empty string.
-	 */
-	newText: string;
-}
-
-export interface ColorPresentation {
-	/**
-	 * The label of this color presentation. It will be shown on the color
-	 * picker header. By default this is also the text that is inserted when selecting
-	 * this color presentation.
-	 */
-	label: string;
-	/**
-	 * An [edit](#TextEdit) which is applied to a document when selecting
-	 * this presentation for the color.  When `falsy` the [label](#ColorPresentation.label)
-	 * is used.
-	 */
-	textEdit?: TextEdit;
-	/**
-	 * An optional array of additional [text edits](#TextEdit) that are applied when
-	 * selecting this color presentation. Edits must not overlap with the main [edit](#ColorPresentation.textEdit) nor with themselves.
-	 */
-	additionalTextEdits?: TextEdit[];
-}
-
-/**
- * Represents a folding range. To be valid, start and end line must be bigger than zero and smaller
- * than the number of lines in the document. Clients are free to ignore invalid ranges.
- */
-export interface FoldingRange {
-	/**
-	 * The zero-based start line of the range to fold. The folded area starts after the line's last character.
-	 * To be valid, the end must be zero or larger and smaller than the number of lines in the document.
-	 */
-	startLine: uinteger;
-	/**
-	 * The zero-based character offset from where the folded range starts. If not defined, defaults to the length of the start line.
-	 */
-	startCharacter?: uinteger;
-	/**
-	 * The zero-based end line of the range to fold. The folded area ends with the line's last character.
-	 * To be valid, the end must be zero or larger and smaller than the number of lines in the document.
-	 */
-	endLine: uinteger;
-	/**
-	 * The zero-based character offset before the folded range ends. If not defined, defaults to the length of the end line.
-	 */
-	endCharacter?: uinteger;
-	/**
-	 * Describes the kind of the folding range such as `comment' or 'region'. The kind
-	 * is used to categorize folding ranges and used by commands like 'Fold all comments'. See
-	 * [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds.
-	 */
-	kind?: string;
-}
-
 export interface BaseASTNode {
 	readonly type: 'object' | 'array' | 'property' | 'string' | 'number' | 'boolean' | 'null';
 	readonly parent?: ASTNode;
@@ -296,22 +206,6 @@ export interface MatchingSchema {
 	node: ASTNode;
 	schema: JSONSchema;
 }
-
-/**
- * A selection range represents a part of a selection hierarchy. A selection range
- * may have a parent selection range that contains it.
- */
-export interface SelectionRange {
-	/**
-	 * The [range](#Range) of this selection range.
-	 */
-	range: Range;
-	/**
-	 * The parent selection range containing this range. Therefore `parent.range` must contain `this.range`.
-	 */
-	parent?: SelectionRange;
-}
-
 /**
  * A tagging type for string properties that are actually document URIs.
  */
@@ -324,85 +218,6 @@ export type DocumentUri = string;
 export interface Location {
 	uri: DocumentUri;
 	range: Range;
-}
-
-export type SymbolKind =
-	| 1
-	| 2
-	| 3
-	| 4
-	| 5
-	| 6
-	| 7
-	| 8
-	| 9
-	| 10
-	| 11
-	| 12
-	| 13
-	| 14
-	| 15
-	| 16
-	| 17
-	| 18
-	| 19
-	| 20
-	| 21
-	| 22
-	| 23
-	| 24
-	| 25
-	| 26;
-
-/**
- * Symbol tags are extra annotations that tweak the rendering of a symbol.
- * @since 3.16
- */
-export type SymbolTag = 1;
-/**
- * Represents information about programming constructs like variables, classes,
- * interfaces etc.
- */
-export interface SymbolInformation {
-	/**
-	 * The name of this symbol.
-	 */
-	name: string;
-	/**
-	 * The kind of this symbol.
-	 */
-	kind: SymbolKind;
-	/**
-	 * Tags for this completion item.
-	 *
-	 * @since 3.16.0
-	 */
-	tags?: SymbolTag[];
-	/**
-	 * Indicates if this symbol is deprecated.
-	 *
-	 * @deprecated Use tags instead
-	 */
-	deprecated?: boolean;
-	/**
-	 * The location of this symbol. The location's range is used by a tool
-	 * to reveal the location in the editor. If the symbol is selected in the
-	 * tool the range's start information is used to position the cursor. So
-	 * the range usually spans more than the actual symbol's name and does
-	 * normally include thinks like visibility modifiers.
-	 *
-	 * The range doesn't have to denote a node range in the sense of a abstract
-	 * syntax tree. It can therefore not be used to re-construct a hierarchy of
-	 * the symbols.
-	 */
-	location: Location;
-	/**
-	 * The name of the symbol containing this symbol. This information is for
-	 * user interface purposes (e.g. to render a qualifier in the user interface
-	 * if necessary). It can't be used to re-infer a hierarchy for the document
-	 * symbols.
-	 */
-	containerName?: string;
 }
 // --- JSON configuration and defaults ---------
 
@@ -596,10 +411,6 @@ export const jsonDefaults: LanguageServiceDefaults = new LanguageServiceDefaults
 );
 
 export interface IJSONWorker {
-	findDocumentSymbols(uri: string): Promise<SymbolInformation[]>;
-	getColorPresentations(uri: string, color: Color, range: Range): Promise<ColorPresentation[]>;
-	getFoldingRanges(uri: string, context?: { rangeLimit?: number }): Promise<FoldingRange[]>;
-	getSelectionRanges(uri: string, positions: Position[]): Promise<SelectionRange[]>;
 	parseJSONDocument(uri: string): Promise<JSONDocument | null>;
 	getMatchingSchemas(uri: string): Promise<MatchingSchema[]>;
 }

--- a/src/language/json/monaco.contribution.ts
+++ b/src/language/json/monaco.contribution.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as mode from './jsonMode';
-import { Emitter, IEvent, languages, Uri } from '../../fillers/monaco-editor-core';
-import type { JSONWorker } from './jsonWorker';
+import { Emitter, IEvent, languages, Uri } from 'monaco-editor-core';
+import * as jsonService from 'vscode-json-languageservice';
 
 // --- JSON configuration and defaults ---------
 
@@ -198,9 +198,27 @@ export const jsonDefaults: LanguageServiceDefaults = new LanguageServiceDefaults
 	modeConfigurationDefault
 );
 
-export const getWorker = (): Promise<(...uris: Uri[]) => Promise<JSONWorker>> => {
-	return getMode().then((mode) => mode.getWorker());
-};
+export interface IJSONWorker {
+	findDocumentSymbols(uri: string): Promise<jsonService.SymbolInformation[]>;
+	getColorPresentations(
+		uri: string,
+		color: jsonService.Color,
+		range: jsonService.Range
+	): Promise<jsonService.ColorPresentation[]>;
+	getFoldingRanges(
+		uri: string,
+		context?: { rangeLimit?: number }
+	): Promise<jsonService.FoldingRange[]>;
+	getSelectionRanges(
+		uri: string,
+		positions: jsonService.Position[]
+	): Promise<jsonService.SelectionRange[]>;
+	parseJSONDocument(uri: string): Promise<jsonService.JSONDocument | null>;
+	getMatchingSchemas(uri: string): Promise<jsonService.MatchingSchema[]>;
+}
+
+export const getWorker = (): Promise<(...uris: Uri[]) => Promise<IJSONWorker>> =>
+	getMode().then((mode) => mode.getWorker());
 
 // export to the global based API
 (<any>languages).json = { jsonDefaults, getWorker };


### PR DESCRIPTION
This PR fixes microsoft#727 and addresses review comments (I think so) from an original PR microsoft#3956 which became stale for some reason.

I just want to get things JSON worker faster to Monaco, because it's needed for my project.

My use case is to provide insights to the end user after analyzing JSON schemas of the edited document. Plus, include the motivation from an original PR: 
> Exposes the JSON worker and the parseDocument function from the JSON Worker.
>
> This is useful when editors want to use the JSON Worker's ability to parse the document, as using a separate parser can result in inconsistencies and does double the work.