### PR TITLE
Support triple mustache as brackets

### DIFF
--- a/src/basic-languages/handlebars/handlebars.ts
+++ b/src/basic-languages/handlebars/handlebars.ts
@@ -34,6 +34,7 @@ export const conf: languages.LanguageConfiguration = {
 	brackets: [
 		['<!--', '-->'],
 		['<', '>'],
+		['{{{', '}}}'],
 		['{{', '}}'],
 		['{', '}'],
 		['(', ')']


### PR DESCRIPTION
According to the [Mustache document](https://mustache.github.io/mustache.5.html#:~:text=all%20variables%20are%20html%20escaped%20by%20default.%20if%20you%20want%20to%20return%20raw%20contents%20without%20escaping%2C%20use%20the%20triple%20mustache%3A%20%7B%7B%7Bname%7D%7D%7D.), the triple mustache is used for non-escaping HTML characters, but Monaco cannot handle it in highlighting. Through this pull request, the triple mustache as brackets.