### PR TITLE
Fix parameter labels

### DIFF
--- a/.azure-pipelines/publish-nightly.yml
+++ b/.azure-pipelines/publish-nightly.yml
@@ -29,7 +29,7 @@ parameters:
     type: boolean
     default: true
   - name: publishMonacoEditor
-    displayName: 🚀 Publish Editor Core
+    displayName: 🚀 Publish Monaco Editor
     type: boolean
     default: true
   - name: vscodeRef

--- a/.azure-pipelines/publish-stable.yml
+++ b/.azure-pipelines/publish-stable.yml
@@ -21,7 +21,7 @@ parameters:
     type: boolean
     default: false
   - name: publishMonacoEditor
-    displayName: 🚀 Publish Editor Core
+    displayName: 🚀 Publish Monaco Editor
     type: boolean
     default: false
   - name: publishWebpackPlugin


### PR DESCRIPTION
This pull request fixes the parameter labels in the `.azure-pipelines/publish-nightly.yml` and `.azure-pipelines/publish-stable.yml` files. The display name for publishing the Monaco Editor Core has been corrected to "🚀 Publish Monaco Editor".