### PR TITLE
Fix: Changed suggested value for IDecorationOptions from RGB to CSS hex color values for the manoce.editor

### DIFF
--- a/node_modules/monaco-editor-core/monaco.d.ts
+++ b/node_modules/monaco-editor-core/monaco.d.ts
@@ -1599,12 +1599,14 @@ declare namespace monaco.editor {
 	export interface IDecorationOptions {
 		/**
 		 * CSS color to render.
-		 * e.g.: rgba(100, 100, 100, 0.5) or a color from the color registry
+		 * Note: Only CSS hex color values are supported.
+         * e.g.: #646464 or a color from the color registry
 		 */
 		color: string | ThemeColor | undefined;
 		/**
 		 * CSS color to render.
-		 * e.g.: rgba(100, 100, 100, 0.5) or a color from the color registry
+		 * Note: Only CSS hex color values are supported.
+         * e.g.: #646464 or a color from the color registry
 		 */
 		darkColor?: string | ThemeColor;
 	}

--- a/node_modules/monaco-editor/monaco.d.ts
+++ b/node_modules/monaco-editor/monaco.d.ts
@@ -1603,13 +1603,15 @@ declare namespace monaco.editor {
 
     export interface IDecorationOptions {
         /**
-         * CSS color to render.
-         * e.g.: rgba(100, 100, 100, 0.5) or a color from the color registry
+         * CSS color to render. 
+         * Note: Only CSS hex color values are supported.
+         * e.g.: #646464 or a color from the color registry
          */
         color: string | ThemeColor | undefined;
         /**
          * CSS color to render.
-         * e.g.: rgba(100, 100, 100, 0.5) or a color from the color registry
+         * Note: Only CSS hex color values are supported.
+         * e.g.: #646464 or a color from the color registry
          */
         darkColor?: string | ThemeColor;
     }


### PR DESCRIPTION
Fixes #4178 

I changed the suggested value for the IDecorationOptions interface from RGB to HEX colour values since that's what it accepts.

