### PR TITLE
Fix: Visual highlight unique color issue

### DIFF
--- a/node_modules/monaco-editor-core/monaco.d.ts
+++ b/node_modules/monaco-editor-core/monaco.d.ts
@@ -1130,6 +1130,9 @@ declare namespace monaco.editor {
 
 	/**
 	 * Define a new theme or update an existing theme.
+	 * Setting the background to #00000000 (transparent) produces an error
+	 * with copying/pasting of code on the editor. Kindly opt for other color
+	 * codes apart from #00000000.
 	 */
 	export function defineTheme(themeName: string, themeData: IStandaloneThemeData): void;
 

--- a/node_modules/monaco-editor/monaco.d.ts
+++ b/node_modules/monaco-editor/monaco.d.ts
@@ -1135,6 +1135,9 @@ declare namespace monaco.editor {
 
     /**
      * Define a new theme or update an existing theme.
+     * Setting the background to #00000000 (transparent) produces an error
+	 * with copying/pasting of code on the editor. Kindly opt for other color
+	 * codes apart from #00000000.
      */
     export function defineTheme(themeName: string, themeData: IStandaloneThemeData): void;
 


### PR DESCRIPTION
Fix #4158 

Added a small warning for devs trying to use the #00000000 (transparent) colour code as a theme as it causes an issue with copying/pasting text on the editor.

See #4158 for more info.