### PR TITLE
chore: add cgIgnoreDirectories

### DIFF
--- a/.azure-pipelines/publish-stable.yml
+++ b/.azure-pipelines/publish-stable.yml
@@ -32,6 +32,7 @@ parameters:
 extends:
   template: azure-pipelines/npm-package/pipeline.yml@templates
   parameters:
+    cgIgnoreDirectories: $(Build.SourcesDirectory)/dependencies/vscode/extensions
     npmPackages:
       - name: monaco-editor-core
         workingDirectory: $(Build.SourcesDirectory)/dependencies/vscode/out-monaco-editor-core


### PR DESCRIPTION
Ignores the dependencies/vscode/extensions folder because

1. The VS Code extensions are scanned elsewhere
2. The VS Code extension package.json files often produce false positives because they share names with published npm packages such as grunt and ini