### PR TITLE
chore: skip APIScan

### DIFF
--- a/.azure-pipelines/publish-nightly.yml
+++ b/.azure-pipelines/publish-nightly.yml
@@ -48,6 +48,7 @@ extends:
       - name: monaco-editor-core
         workingDirectory: $(Build.SourcesDirectory)/dependencies/vscode/out-monaco-editor-core
         testPlatforms: []
+        skipAPIScan: true # package build requires Linux
         buildSteps:
           - script: sudo apt install -y libkrb5-dev
             displayName: Install libkrb5-dev

--- a/.azure-pipelines/publish-stable.yml
+++ b/.azure-pipelines/publish-stable.yml
@@ -35,6 +35,7 @@ extends:
     npmPackages:
       - name: monaco-editor-core
         workingDirectory: $(Build.SourcesDirectory)/dependencies/vscode/out-monaco-editor-core
+        testPlatforms: []
         skipAPIScan: true
         buildSteps:
           - script: sudo apt install -y libkrb5-dev
@@ -53,10 +54,7 @@ extends:
 
       - name: monaco-editor
         workingDirectory: $(Build.SourcesDirectory)/out/monaco-editor
-        testPlatforms:
-          - name: Windows
-            nodeVersions:
-              - 18.17.x
+        testPlatforms: []
         packagePlatform: Windows
         buildSteps:
           - script: npm ci
@@ -71,10 +69,7 @@ extends:
 
       - name: monaco-editor-webpack-plugin
         workingDirectory: $(Build.SourcesDirectory)/webpack-plugin
-        testPlatforms:
-          - name: Windows
-            nodeVersions:
-              - 18.17.x
+        testPlatforms: []
         packagePlatform: Windows
         buildSteps:
           - script: npm ci

--- a/.azure-pipelines/publish-stable.yml
+++ b/.azure-pipelines/publish-stable.yml
@@ -35,12 +35,11 @@ extends:
     npmPackages:
       - name: monaco-editor-core
         workingDirectory: $(Build.SourcesDirectory)/dependencies/vscode/out-monaco-editor-core
-        testPlatforms:
-          - name: Windows
-            nodeVersions:
-              - 18.17.x
-        packagePlatform: Windows
+        apiScanSkip: true
         buildSteps:
+          - script: sudo apt install -y libkrb5-dev
+            displayName: Install libkrb5-dev
+
           - script: npm ci
             displayName: Install NPM dependencies
 

--- a/.azure-pipelines/publish-stable.yml
+++ b/.azure-pipelines/publish-stable.yml
@@ -41,9 +41,6 @@ extends:
               - 18.17.x
         packagePlatform: Windows
         buildSteps:
-          - script: sudo apt install -y libkrb5-dev
-            displayName: Install libkrb5-dev
-
           - script: npm ci
             displayName: Install NPM dependencies
 

--- a/.azure-pipelines/publish-stable.yml
+++ b/.azure-pipelines/publish-stable.yml
@@ -35,7 +35,11 @@ extends:
     npmPackages:
       - name: monaco-editor-core
         workingDirectory: $(Build.SourcesDirectory)/dependencies/vscode/out-monaco-editor-core
-        testPlatforms: []
+        testPlatforms:
+          - name: Windows
+            nodeVersions:
+              - 18.17.x
+        packagePlatform: Windows
         buildSteps:
           - script: sudo apt install -y libkrb5-dev
             displayName: Install libkrb5-dev
@@ -53,7 +57,11 @@ extends:
 
       - name: monaco-editor
         workingDirectory: $(Build.SourcesDirectory)/out/monaco-editor
-        testPlatforms: []
+        testPlatforms:
+          - name: Windows
+            nodeVersions:
+              - 18.17.x
+        packagePlatform: Windows
         buildSteps:
           - script: npm ci
             displayName: Install NPM dependencies
@@ -67,7 +75,11 @@ extends:
 
       - name: monaco-editor-webpack-plugin
         workingDirectory: $(Build.SourcesDirectory)/webpack-plugin
-        testPlatforms: []
+        testPlatforms:
+          - name: Windows
+            nodeVersions:
+              - 18.17.x
+        packagePlatform: Windows
         buildSteps:
           - script: npm ci
             displayName: Install NPM dependencies

--- a/.azure-pipelines/publish-stable.yml
+++ b/.azure-pipelines/publish-stable.yml
@@ -35,7 +35,7 @@ extends:
     npmPackages:
       - name: monaco-editor-core
         workingDirectory: $(Build.SourcesDirectory)/dependencies/vscode/out-monaco-editor-core
-        apiScanSkip: true
+        skipAPIScan: true
         buildSteps:
           - script: sudo apt install -y libkrb5-dev
             displayName: Install libkrb5-dev

--- a/.azure-pipelines/publish-stable.yml
+++ b/.azure-pipelines/publish-stable.yml
@@ -36,7 +36,7 @@ extends:
       - name: monaco-editor-core
         workingDirectory: $(Build.SourcesDirectory)/dependencies/vscode/out-monaco-editor-core
         testPlatforms: []
-        skipAPIScan: true
+        skipAPIScan: true # package build requires Linux
         buildSteps:
           - script: sudo apt install -y libkrb5-dev
             displayName: Install libkrb5-dev
@@ -55,7 +55,7 @@ extends:
       - name: monaco-editor
         workingDirectory: $(Build.SourcesDirectory)/out/monaco-editor
         testPlatforms: []
-        packagePlatform: Windows
+        skipAPIScan: true # package build requires Linux
         buildSteps:
           - script: npm ci
             displayName: Install NPM dependencies


### PR DESCRIPTION
Some of the builds require Linux, so we skip APIScan for those builds.
Will investigate why the nightly build's broken separately.