### PR TITLE
Fix bug with highlighting of C++ raw string literals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 				"jsdom": "^19.0.0",
 				"jsonc-parser": "^3.0.0",
 				"mocha": "^9.2.0",
-				"monaco-editor-core": "0.48.0-dev-20240319",
+				"monaco-editor-core": "0.48.0-dev-20240320",
 				"parcel": "^2.7.0",
 				"pin-github-action": "^1.8.0",
 				"playwright": "^1.32.2",
@@ -5388,9 +5388,9 @@
 			"dev": true
 		},
 		"node_modules/monaco-editor-core": {
-			"version": "0.48.0-dev-20240319",
-			"resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.48.0-dev-20240319.tgz",
-			"integrity": "sha512-w8QasiJcJY/XPHPqtqj1+aokHrFIFBYuKOOABFT9vDmTEp/0euMxARhwc0R1VvtQ1hSFVKb0CQq6X1kMdgvbbQ==",
+			"version": "0.48.0-dev-20240320",
+			"resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.48.0-dev-20240320.tgz",
+			"integrity": "sha512-fXS0Bt39Qv9C10Cuuf0ZvgcK8LhN+fP+27sDfjILEQCUVRa4pDAtvZOny2BiiPqsmOINch8UVNSZtH7+Af3ngQ==",
 			"dev": true
 		},
 		"node_modules/mri": {
@@ -11144,9 +11144,9 @@
 			}
 		},
 		"monaco-editor-core": {
-			"version": "0.48.0-dev-20240319",
-			"resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.48.0-dev-20240319.tgz",
-			"integrity": "sha512-w8QasiJcJY/XPHPqtqj1+aokHrFIFBYuKOOABFT9vDmTEp/0euMxARhwc0R1VvtQ1hSFVKb0CQq6X1kMdgvbbQ==",
+			"version": "0.48.0-dev-20240320",
+			"resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.48.0-dev-20240320.tgz",
+			"integrity": "sha512-fXS0Bt39Qv9C10Cuuf0ZvgcK8LhN+fP+27sDfjILEQCUVRa4pDAtvZOny2BiiPqsmOINch8UVNSZtH7+Af3ngQ==",
 			"dev": true
 		},
 		"mri": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"jsdom": "^19.0.0",
 		"jsonc-parser": "^3.0.0",
 		"mocha": "^9.2.0",
-		"monaco-editor-core": "0.48.0-dev-20240319",
+		"monaco-editor-core": "0.48.0-dev-20240320",
 		"parcel": "^2.7.0",
 		"pin-github-action": "^1.8.0",
 		"playwright": "^1.32.2",

--- a/src/basic-languages/cpp/cpp.ts
+++ b/src/basic-languages/cpp/cpp.ts
@@ -378,20 +378,7 @@ export const language = <languages.IMonarchLanguage>{
 		],
 
 		raw: [
-			[
-				/(.*)(\))(?:([^ ()\\\t"]*))(\")/,
-				{
-					cases: {
-						'$3==$S2': [
-							'string.raw',
-							'string.raw.end',
-							'string.raw.end',
-							{ token: 'string.raw.end', next: '@pop' }
-						],
-						'@default': ['string.raw', 'string.raw', 'string.raw', 'string.raw']
-					}
-				}
-			],
+			[/.*\)$S2\"/, 'string.raw', '@pop'],
 			[/.*/, 'string.raw']
 		],
 

--- a/src/basic-languages/cpp/cpp.ts
+++ b/src/basic-languages/cpp/cpp.ts
@@ -378,8 +378,9 @@ export const language = <languages.IMonarchLanguage>{
 		],
 
 		raw: [
-			[/.*\)$S2\"/, 'string.raw', '@pop'],
-			[/.*/, 'string.raw']
+			[/[^)]+/, 'string.raw'],
+			[/\)$S2\"/, { token: 'string.raw.end', next: '@pop' }],
+			[/\)/, 'string.raw']
 		],
 
 		annotation: [


### PR DESCRIPTION
Since https://github.com/microsoft/vscode/pull/183463 was merged it should now be possible to fix #3128 with this.

In order to test it I need to be able to be able to run the monaco-editor locally with this new change from upstream. What can I do to get that change locally?