### PR TITLE
chore: CG ignore VS Code extensions for nightly

### DIFF
--- a/.azure-pipelines/publish-nightly.yml
+++ b/.azure-pipelines/publish-nightly.yml
@@ -44,6 +44,7 @@ parameters:
 extends:
   template: azure-pipelines/npm-package/pipeline.yml@templates
   parameters:
+    cgIgnoreDirectories: $(Build.SourcesDirectory)/dependencies/vscode/extensions
     npmPackages:
       - name: monaco-editor-core
         workingDirectory: $(Build.SourcesDirectory)/dependencies/vscode/out-monaco-editor-core


### PR DESCRIPTION
Some VS Code CG scan results are being re-reported by the monaco-editor (nightly) CG scan. This PR ignores the dependencies/vscode/extensions folder to close some duplicate CG results.

@hediet is it possible for the monaco-editor pipeline to pull in an outdated version of VS Code? If not, I believe we can ignore the entire dependencies/vscode folder in a future PR.