### PR TITLE
Call clearFiles on internal EmitOutput diagnostics

### DIFF
--- a/src/language/typescript/monaco.contribution.ts
+++ b/src/language/typescript/monaco.contribution.ts
@@ -216,9 +216,10 @@ export interface DiagnosticRelatedInformation {
 	messageText: string | DiagnosticMessageChain;
 }
 
-interface EmitOutput {
+export interface EmitOutput {
 	outputFiles: OutputFile[];
 	emitSkipped: boolean;
+	diagnostics?: Diagnostic[];
 }
 interface OutputFile {
 	name: string;

--- a/src/language/typescript/tsWorker.ts
+++ b/src/language/typescript/tsWorker.ts
@@ -8,6 +8,7 @@ import { libFileMap } from './lib/lib';
 import {
 	Diagnostic,
 	DiagnosticRelatedInformation,
+	EmitOutput,
 	IExtraLibs,
 	TypeScriptWorker as ITypeScriptWorker
 } from './monaco.contribution';
@@ -401,11 +402,18 @@ export class TypeScriptWorker implements ts.LanguageServiceHost, ITypeScriptWork
 		return this._languageService.getRenameInfo(fileName, position, options);
 	}
 
-	async getEmitOutput(fileName: string): Promise<ts.EmitOutput> {
+	async getEmitOutput(fileName: string): Promise<EmitOutput> {
 		if (fileNameIsLib(fileName)) {
 			return { outputFiles: [], emitSkipped: true };
 		}
-		return this._languageService.getEmitOutput(fileName);
+		// The diagnostics property is internal, returning it without clearing breaks message serialization.
+		const emitOutput = this._languageService.getEmitOutput(fileName) as ts.EmitOutput & {
+			diagnostics?: ts.Diagnostic[];
+		};
+		const diagnostics = emitOutput.diagnostics
+			? TypeScriptWorker.clearFiles(emitOutput.diagnostics)
+			: undefined;
+		return { ...emitOutput, diagnostics };
 	}
 
 	async getCodeFixesAtPosition(


### PR DESCRIPTION
Emitting produces diagnostics. Unfortunately, these are marked as internal so were missed (https://github.com/microsoft/TypeScript/pull/58317)

This change enables the playground to handle emit errors without crashing.