### PR TITLE
Change elseif to elsif to match liquid

### DIFF
--- a/src/basic-languages/liquid/liquid.ts
+++ b/src/basic-languages/liquid/liquid.ts
@@ -79,7 +79,7 @@ export const language = <languages.IMonarchLanguage>{
 	builtinTags: [
 		'if',
 		'else',
-		'elseif',
+		'elsif',
 		'endif',
 		'render',
 		'assign',


### PR DESCRIPTION
The liquid tag for else if is actually `elsif` not `elseif`

See [https://shopify.github.io/liquid/tags/control-flow/#:~:text=%7B%25%20endif%20%25%7D-,elsif%20/%20else,-Adds%20more%20conditions](Shopify docmentation)