### PR TITLE
Add extension to `csp.contribution.ts`

### DIFF
--- a/src/basic-languages/csp/csp.contribution.ts
+++ b/src/basic-languages/csp/csp.contribution.ts
@@ -10,7 +10,7 @@ declare var require: any;
 
 registerLanguage({
 	id: 'csp',
-	extensions: [],
+	extensions: ['.csp'],
 	aliases: ['CSP', 'csp'],
 	loader: () => {
 		if (AMD) {


### PR DESCRIPTION
Adds the missing extension value for the CSP langugage in `csp.contribution.ts`.

**Fixes: #4503**

---

_xref: microsoft/PowerToys/issues/32771_