### PR TITLE
chore: exclude all vscode from CG

### DIFF
--- a/.azure-pipelines/publish-nightly.yml
+++ b/.azure-pipelines/publish-nightly.yml
@@ -44,7 +44,7 @@ parameters:
 extends:
   template: azure-pipelines/npm-package/pipeline.yml@templates
   parameters:
-    cgIgnoreDirectories: $(Build.SourcesDirectory)/dependencies/vscode/extensions
+    cgIgnoreDirectories: $(Build.SourcesDirectory)/dependencies/vscode
     npmPackages:
       - name: monaco-editor-core
         workingDirectory: $(Build.SourcesDirectory)/dependencies/vscode/out-monaco-editor-core

--- a/.azure-pipelines/publish-stable.yml
+++ b/.azure-pipelines/publish-stable.yml
@@ -32,7 +32,7 @@ parameters:
 extends:
   template: azure-pipelines/npm-package/pipeline.yml@templates
   parameters:
-    cgIgnoreDirectories: $(Build.SourcesDirectory)/dependencies/vscode/extensions
+    cgIgnoreDirectories: $(Build.SourcesDirectory)/dependencies/vscode
     npmPackages:
       - name: monaco-editor-core
         workingDirectory: $(Build.SourcesDirectory)/dependencies/vscode/out-monaco-editor-core


### PR DESCRIPTION
This PR excludes all vscode folders from CG. I have confirmed that the scanned results already show up in a separate CG scan.