### PR TITLE
fix: make all moduleResolution values available

### DIFF
--- a/src/language/typescript/monaco.contribution.ts
+++ b/src/language/typescript/monaco.contribution.ts
@@ -49,7 +49,11 @@ export enum ScriptTarget {
 
 export enum ModuleResolutionKind {
 	Classic = 1,
-	NodeJs = 2
+	NodeJs = 2,
+	Node10 = 2,
+	Node16 = 3,
+	NodeNext = 99,
+	Bundler = 100
 }
 //#endregion
 


### PR DESCRIPTION
adds additional members to the `ModuleResolutionKind` enum to make all possible `moduleResolution` values available.

the values are based on the enum in `typescriptServices.js`, namely:
```javascript
      ModuleResolutionKind = /* @__PURE__ */ ((ModuleResolutionKind3) => {
        ModuleResolutionKind3[ModuleResolutionKind3["Classic"] = 1] = "Classic";
        ModuleResolutionKind3[ModuleResolutionKind3["NodeJs"] = 2] = "NodeJs";
        ModuleResolutionKind3[ModuleResolutionKind3["Node10"] = 2] = "Node10";
        ModuleResolutionKind3[ModuleResolutionKind3["Node16"] = 3] = "Node16";
        ModuleResolutionKind3[ModuleResolutionKind3["NodeNext"] = 99] = "NodeNext";
        ModuleResolutionKind3[ModuleResolutionKind3["Bundler"] = 100] = "Bundler";
        return ModuleResolutionKind3;
```

from a developer experience perspective I would actually prefer if the enum was replaced with the string values that you would use in `tsconfig.json` as I'd find this more intuitive, but this would be a larger breaking change.

motivation for this change is that I'm building out a playground for [my project](https://openapi-code-generator.nahkies.co.nz/overview/about) and it makes use of the `exports` field in `package.json` files which require `"moduleResolution": "Node16"` https://github.com/mnahkies/openapi-code-generator/blob/main/packages/typescript-koa-runtime/package.json#L18-L39

I'm working around by adjusting the `.d.ts` file locations in the virtual filesystem to drop the `dist` directory which makes it work, but it would be nicer if I could just leave them in their original locations / not special case these packages.