### PR TITLE
Add gjs to Javascript lang firstLine

### DIFF
--- a/src/basic-languages/javascript/javascript.contribution.ts
+++ b/src/basic-languages/javascript/javascript.contribution.ts
@@ -11,7 +11,7 @@ declare var require: any;
 registerLanguage({
 	id: 'javascript',
 	extensions: ['.js', '.es6', '.jsx', '.mjs', '.cjs'],
-	firstLine: '^#!.*\\bnode',
+	firstLine: "^#!.*\\b(node|gjs)",
 	filenames: ['jakefile'],
 	aliases: ['JavaScript', 'javascript', 'js'],
 	mimetypes: ['text/javascript'],


### PR DESCRIPTION
## What

Extend the `firstLang` regex in the Javascript `registerLanguage` to match lines like `#!/usr/bin/env gjs`.

## Why

This adds automatic language detection for [GJS scripts](https://gjs.guide/guides/gtk/3/04-running-gtk.html). GJS is Javascript for Gnome and GTK.