### PR TITLE
C# raw string literal

### DIFF
--- a/src/basic-languages/csharp/csharp.test.ts
+++ b/src/basic-languages/csharp/csharp.test.ts
@@ -972,5 +972,42 @@ testTokenization('csharp', [
 				{ startIndex: 45, type: 'delimiter.cs' }
 			]
 		}
+	],
+
+	// Raw String Literals
+	[
+		{
+			line: 'var singleLine = """This is a "raw string literal". It can contain characters like , \' and ".""";',
+			tokens: [
+				{ startIndex: 0, type: 'keyword.var.cs' },
+				{ startIndex: 3, type: '' },
+				{ startIndex: 4, type: 'identifier.cs' },
+				{ startIndex: 14, type: '' },
+				{ startIndex: 15, type: 'delimiter.cs' },
+				{ startIndex: 16, type: '' },
+				{ startIndex: 17, type: 'string.quote.cs' },
+				{ startIndex: 20, type: 'string.cs' },
+				{ startIndex: 93, type: 'string.quote.cs' },
+				{ startIndex: 96, type: 'delimiter.cs' }
+			]
+		}
+	],
+
+	[
+		{
+			line: 'var moreQuotes = """" As you can see,"""Raw string literals""" can start and end with more than three double-quotes when needed."""";',
+			tokens: [
+				{ startIndex: 0, type: 'keyword.var.cs' },
+				{ startIndex: 3, type: '' },
+				{ startIndex: 4, type: 'identifier.cs' },
+				{ startIndex: 14, type: '' },
+				{ startIndex: 15, type: 'delimiter.cs' },
+				{ startIndex: 16, type: '' },
+				{ startIndex: 17, type: 'string.quote.cs' },
+				{ startIndex: 21, type: 'string.cs' },
+				{ startIndex: 128, type: 'string.quote.cs' },
+				{ startIndex: 132, type: 'delimiter.cs' }
+			]
+		}
 	]
 ]);

--- a/src/basic-languages/csharp/csharp.ts
+++ b/src/basic-languages/csharp/csharp.ts
@@ -269,7 +269,8 @@ export const language = <languages.IMonarchLanguage>{
 			[/[;,.]/, 'delimiter'],
 
 			// strings
-			[/"([^"\\]|\\.)*$/, 'string.invalid'], // non-teminated string
+			[/("{3,})/, { token: 'string.quote', next: '@rawstring.$1' }], // raw string literal
+			[/"([^"\\]|\\.)*$/, 'string.invalid'], // non-terminated string
 			[/"/, { token: 'string.quote', next: '@string' }],
 			[/\$\@"/, { token: 'string.quote', next: '@litinterpstring' }],
 			[/\@"/, { token: 'string.quote', next: '@litstring' }],
@@ -314,6 +315,20 @@ export const language = <languages.IMonarchLanguage>{
 			[/@escapes/, 'string.escape'],
 			[/\\./, 'string.escape.invalid'],
 			[/"/, { token: 'string.quote', next: '@pop' }]
+		],
+
+		rawstring: [
+			[/[^"]+/, 'string'],
+			[
+				/("{3,})/,
+				{
+					cases: {
+						'$1==$S2': { token: 'string.quote', next: '@pop' },
+						'@default': { token: 'string' }
+					}
+				}
+			],
+			[/["]/, 'string']
 		],
 
 		litstring: [


### PR DESCRIPTION
- Support C# raw string literals (cf https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/raw-string)
- It starts by a minimum of three `"` and end by the same numberf of `#`