### PR TITLE
Add missing enum and moduleDetection config to CompilerOptions

### DIFF
--- a/src/language/typescript/monaco.contribution.ts
+++ b/src/language/typescript/monaco.contribution.ts
@@ -47,6 +47,12 @@ export enum ScriptTarget {
 	Latest = ESNext
 }
 
+export enum ModuleDetectionKind {
+	Legacy = 1,
+	Auto = 2,
+	Force = 3
+}
+
 export enum ModuleResolutionKind {
 	Classic = 1,
 	NodeJs = 2
@@ -99,6 +105,7 @@ interface CompilerOptions {
 	mapRoot?: string;
 	maxNodeModuleJsDepth?: number;
 	module?: ModuleKind;
+	moduleDetection?: ModuleDetectionKind;
 	moduleResolution?: ModuleResolutionKind;
 	newLine?: NewLineKind;
 	noEmit?: boolean;


### PR DESCRIPTION
I found that the types available when using the Monaco editor API to set compiler options for TypeScript are out of sync with the actual options. Probably the real solution is to make sure there is only one source of truth for this, but this particular change indirectly fixes #2976 which I saw as a recurring issue for many people.
