### PR TITLE
Add support for HTML-like Javascript comments

### DIFF
--- a/src/basic-languages/typescript/typescript.ts
+++ b/src/basic-languages/typescript/typescript.ts
@@ -10,7 +10,7 @@ export const conf: languages.LanguageConfiguration = {
 		/(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
 
 	comments: {
-		lineComment: '//',
+		lineComment: ['//', '<!--'],
 		blockComment: ['/*', '*/']
 	},
 


### PR DESCRIPTION
In Javascript, it is possible to make single-line comments in a similar syntax to HTML, by prepending `<!--` before the comment. This has been supported by most (if not all) Javascript engines yet has not been supported by Monaco. This PR fixes this. 