### PR TITLE
Add support for Python multiline f-strings

### DIFF
--- a/src/basic-languages/python/python.test.ts
+++ b/src/basic-languages/python/python.test.ts
@@ -216,6 +216,57 @@ testTokenization('python', [
 			]
 		}
 	],
+
+	// https://github.com/microsoft/monaco-editor/issues/4601
+	[
+		{
+			line: `f'''str `,
+			tokens: [
+				{ startIndex: 0, type: 'string.escape.python' },
+				{ startIndex: 4, type: 'string.python' }
+			]
+		},
+		{
+			line: ` str "{var}" {{ {{ }} `,
+			tokens: [
+				{ startIndex: 0, type: 'string.python' },
+				{ startIndex: 6, type: 'identifier.python' },
+				{ startIndex: 11, type: 'string.python' }
+			]
+		},
+		{
+			line: `str'''`,
+			tokens: [
+				{ startIndex: 0, type: 'string.python' },
+				{ startIndex: 3, type: 'string.escape.python' }
+			]
+		}
+	],
+	[
+		{
+			line: `f"""str `,
+			tokens: [
+				{ startIndex: 0, type: 'string.escape.python' },
+				{ startIndex: 4, type: 'string.python' }
+			]
+		},
+		{
+			line: ` str '{var}' {{ {{ }} `,
+			tokens: [
+				{ startIndex: 0, type: 'string.python' },
+				{ startIndex: 6, type: 'identifier.python' },
+				{ startIndex: 11, type: 'string.python' }
+			]
+		},
+		{
+			line: `str"""`,
+			tokens: [
+				{ startIndex: 0, type: 'string.python' },
+				{ startIndex: 3, type: 'string.escape.python' }
+			]
+		}
+	],
+
 	[
 		{
 			line: 'f"{var:.3f}{var!r}{var=}"',

--- a/src/basic-languages/python/python.ts
+++ b/src/basic-languages/python/python.ts
@@ -257,7 +257,8 @@ export const language = <languages.IMonarchLanguage>{
 			[/"/, 'string.escape', '@dblStringBody']
 		],
 		fStringBody: [
-			[/[^\\'\{\}]+$/, 'string', '@popall'],
+			[/\{\{/, 'string'],
+			[/\}\}/, 'string'],
 			[/[^\\'\{\}]+/, 'string'],
 			[/\{[^\}':!=]+/, 'identifier', '@fStringDetail'],
 			[/\\./, 'string'],
@@ -272,7 +273,8 @@ export const language = <languages.IMonarchLanguage>{
 			[/\\$/, 'string']
 		],
 		fDblStringBody: [
-			[/[^\\"\{\}]+$/, 'string', '@popall'],
+			[/\{\{/, 'string'],
+			[/\}\}/, 'string'],
 			[/[^\\"\{\}]+/, 'string'],
 			[/\{[^\}':!=]+/, 'identifier', '@fStringDetail'],
 			[/\\./, 'string'],


### PR DESCRIPTION
Initial support for f-strings was added in
https://github.com/microsoft/monaco-editor/pull/4401, but it didn't support multiline f-strings, as reported in
https://github.com/microsoft/monaco-editor/issues/4601