### PR TITLE
Update webpack plugin to support module workers

### DIFF
--- a/webpack-plugin/package.json
+++ b/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "monaco-editor-webpack-plugin",
-	"version": "7.1.0",
+	"version": "7.1.1",
 	"description": "A webpack plugin for the Monaco Editor",
 	"main": "out/index.js",
 	"typings": "./out/index.d.ts",

--- a/webpack-plugin/src/index.ts
+++ b/webpack-plugin/src/index.ts
@@ -296,7 +296,14 @@ function createLoaderRules(
               if(/^(\\/\\/)/.test(result)) {
                 result = window.location.protocol + result
               }
-              var js = '/*' + label + '*/importScripts("' + result + '");';
+              var js = '/*' + label + '*/';
+              if (typeof import.meta !== 'undefined') {
+                // module worker
+                js += 'import "' + result + '";';
+              } else {
+                // classic worker
+                js += 'importScripts("' + result + '");';
+              }
               var blob = new Blob([js], { type: 'application/javascript' });
               return URL.createObjectURL(blob);
             }


### PR DESCRIPTION
This is a proposed fix for #4741 .

This PR updates the `monaco-editor-webpack-plugin`'s `getWorkerUrl` to add support for module workers. The function now checks if `import.meta` is defined, and if so, uses `import` to load the worker script. Otherwise, it falls back to using `importScripts` for classic workers.