### PR TITLE
docs: change `var require` to `window.require`

### DIFF
--- a/samples/browser-script-editor/index.html
+++ b/samples/browser-script-editor/index.html
@@ -13,7 +13,7 @@
 		<div id="container" style="width: 800px; height: 600px; border: 1px solid grey"></div>
 
 		<script>
-			var require = { paths: { vs: '../node_modules/monaco-editor/min/vs' } };
+			window.require = { paths: { vs: '../node_modules/monaco-editor/min/vs' } };
 		</script>
 		<script src="../node_modules/monaco-editor/min/vs/loader.js"></script>
 		<script src="../node_modules/monaco-editor/min/vs/editor/editor.main.js"></script>


### PR DESCRIPTION
The browser script edtior sample use `var require = ...`

In some senario var would be auto replaced to `const` (ESLint eg.). And would cause worker not found, so as other resource files.
