### PR TITLE
Bump samples to use monaco-editor version 0.52.0 and apply audit fix

### DIFF
--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -14,7 +14,7 @@
 				"file-loader": "^6.2.0",
 				"glob": "^7.2.0",
 				"html-webpack-plugin": "^5.5.0",
-				"monaco-editor": "^0.32.1",
+				"monaco-editor": "^0.52.0",
 				"monaco-editor-webpack-plugin": "^7.0.1",
 				"style-loader": "^3.3.1",
 				"terser-webpack-plugin": "^5.3.1",
@@ -77,21 +77,23 @@
 			"license": "MIT"
 		},
 		"node_modules/@electron/get/node_modules/semver": {
-			"version": "6.3.0",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
-			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.2",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/set-array": "^1.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/trace-mapping": "^0.3.24"
 			},
 			"engines": {
 				"node": ">=6.0.0"
@@ -106,20 +108,22 @@
 			}
 		},
 		"node_modules/@jridgewell/set-array": {
-			"version": "1.1.2",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@jridgewell/source-map": {
-			"version": "0.3.2",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+			"integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25"
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
@@ -128,12 +132,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.14",
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"node_modules/@leichtgewicht/ip-codec": {
@@ -209,27 +214,30 @@
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.4.5",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+			"integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
 			}
 		},
 		"node_modules/@types/eslint-scope": {
-			"version": "3.7.4",
+			"version": "3.7.7",
+			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@types/eslint": "*",
 				"@types/estree": "*"
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT"
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+			"dev": true
 		},
 		"node_modules/@types/express": {
 			"version": "4.17.13",
@@ -366,133 +374,148 @@
 			}
 		},
 		"node_modules/@webassemblyjs/ast": {
-			"version": "1.11.1",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+			"integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@webassemblyjs/helper-numbers": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+				"@webassemblyjs/helper-numbers": "1.13.2",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2"
 			}
 		},
 		"node_modules/@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.11.1",
-			"dev": true,
-			"license": "MIT"
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+			"integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+			"dev": true
 		},
 		"node_modules/@webassemblyjs/helper-api-error": {
-			"version": "1.11.1",
-			"dev": true,
-			"license": "MIT"
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+			"integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+			"dev": true
 		},
 		"node_modules/@webassemblyjs/helper-buffer": {
-			"version": "1.11.1",
-			"dev": true,
-			"license": "MIT"
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+			"integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+			"dev": true
 		},
 		"node_modules/@webassemblyjs/helper-numbers": {
-			"version": "1.11.1",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+			"integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
-				"@webassemblyjs/helper-api-error": "1.11.1",
+				"@webassemblyjs/floating-point-hex-parser": "1.13.2",
+				"@webassemblyjs/helper-api-error": "1.13.2",
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"node_modules/@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.11.1",
-			"dev": true,
-			"license": "MIT"
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+			"integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+			"dev": true
 		},
 		"node_modules/@webassemblyjs/helper-wasm-section": {
-			"version": "1.11.1",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+			"integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1"
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-buffer": "1.14.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/wasm-gen": "1.14.1"
 			}
 		},
 		"node_modules/@webassemblyjs/ieee754": {
-			"version": "1.11.1",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+			"integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"node_modules/@webassemblyjs/leb128": {
-			"version": "1.11.1",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+			"integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"dependencies": {
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"node_modules/@webassemblyjs/utf8": {
-			"version": "1.11.1",
-			"dev": true,
-			"license": "MIT"
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+			"integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+			"dev": true
 		},
 		"node_modules/@webassemblyjs/wasm-edit": {
-			"version": "1.11.1",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+			"integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/helper-wasm-section": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1",
-				"@webassemblyjs/wasm-opt": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1",
-				"@webassemblyjs/wast-printer": "1.11.1"
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-buffer": "1.14.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/helper-wasm-section": "1.14.1",
+				"@webassemblyjs/wasm-gen": "1.14.1",
+				"@webassemblyjs/wasm-opt": "1.14.1",
+				"@webassemblyjs/wasm-parser": "1.14.1",
+				"@webassemblyjs/wast-printer": "1.14.1"
 			}
 		},
 		"node_modules/@webassemblyjs/wasm-gen": {
-			"version": "1.11.1",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+			"integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/ieee754": "1.11.1",
-				"@webassemblyjs/leb128": "1.11.1",
-				"@webassemblyjs/utf8": "1.11.1"
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/ieee754": "1.13.2",
+				"@webassemblyjs/leb128": "1.13.2",
+				"@webassemblyjs/utf8": "1.13.2"
 			}
 		},
 		"node_modules/@webassemblyjs/wasm-opt": {
-			"version": "1.11.1",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+			"integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1"
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-buffer": "1.14.1",
+				"@webassemblyjs/wasm-gen": "1.14.1",
+				"@webassemblyjs/wasm-parser": "1.14.1"
 			}
 		},
 		"node_modules/@webassemblyjs/wasm-parser": {
-			"version": "1.11.1",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+			"integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-api-error": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/ieee754": "1.11.1",
-				"@webassemblyjs/leb128": "1.11.1",
-				"@webassemblyjs/utf8": "1.11.1"
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-api-error": "1.13.2",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/ieee754": "1.13.2",
+				"@webassemblyjs/leb128": "1.13.2",
+				"@webassemblyjs/utf8": "1.13.2"
 			}
 		},
 		"node_modules/@webassemblyjs/wast-printer": {
-			"version": "1.11.1",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+			"integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/ast": "1.14.1",
 				"@xtuc/long": "4.2.2"
 			}
 		},
@@ -531,13 +554,15 @@
 		},
 		"node_modules/@xtuc/ieee754": {
 			"version": "1.2.0",
-			"dev": true,
-			"license": "BSD-3-Clause"
+			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+			"dev": true
 		},
 		"node_modules/@xtuc/long": {
 			"version": "4.2.2",
-			"dev": true,
-			"license": "Apache-2.0"
+			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+			"dev": true
 		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
@@ -552,22 +577,15 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.8.0",
+			"version": "8.14.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
 			"dev": true,
-			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/acorn-import-assertions": {
-			"version": "1.8.0",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"acorn": "^8"
 			}
 		},
 		"node_modules/ajv": {
@@ -761,7 +779,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.21.3",
+			"version": "4.24.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+			"integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
 			"dev": true,
 			"funding": [
 				{
@@ -771,14 +791,17 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
-			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001370",
-				"electron-to-chromium": "^1.4.202",
-				"node-releases": "^2.0.6",
-				"update-browserslist-db": "^1.0.5"
+				"caniuse-lite": "^1.0.30001669",
+				"electron-to-chromium": "^1.5.41",
+				"node-releases": "^2.0.18",
+				"update-browserslist-db": "^1.1.1"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -878,7 +901,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001375",
+			"version": "1.0.30001684",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001684.tgz",
+			"integrity": "sha512-G1LRwLIQjBQoyq0ZJGqGIJUXzJ8irpbjHLpVRXDvBEScFJ9b17sgK6vlx0GAJFE21okD7zXl08rRRUfq6HdoEQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -888,9 +913,12 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
-			],
-			"license": "CC-BY-4.0"
+			]
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
@@ -1110,9 +1138,9 @@
 			}
 		},
 		"node_modules/cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+			"integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
@@ -1129,9 +1157,10 @@
 			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -1420,9 +1449,10 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.215",
-			"dev": true,
-			"license": "ISC"
+			"version": "1.5.64",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.64.tgz",
+			"integrity": "sha512-IXEuxU+5ClW2IGEYFC2T7szbyVgehupCWQe5GNh+H065CD6U6IFN0s4KeAMFGNmQolRU4IV7zGBWSYMmZ8uuqQ==",
+			"dev": true
 		},
 		"node_modules/electron/node_modules/@types/node": {
 			"version": "16.18.14",
@@ -1455,9 +1485,10 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.10.0",
+			"version": "5.17.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+			"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
 				"tapable": "^2.2.0"
@@ -1515,9 +1546,10 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "0.9.3",
-			"dev": true,
-			"license": "MIT"
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
+			"integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
+			"dev": true
 		},
 		"node_modules/es6-error": {
 			"version": "4.1.1",
@@ -1526,9 +1558,10 @@
 			"optional": true
 		},
 		"node_modules/escalade": {
-			"version": "3.1.1",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -1634,9 +1667,9 @@
 			}
 		},
 		"node_modules/express": {
-			"version": "4.21.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-			"integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+			"version": "4.21.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+			"integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
 			"dev": true,
 			"dependencies": {
 				"accepts": "~1.3.8",
@@ -1644,7 +1677,7 @@
 				"body-parser": "1.20.3",
 				"content-disposition": "0.5.4",
 				"content-type": "~1.0.4",
-				"cookie": "0.6.0",
+				"cookie": "0.7.1",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
@@ -1993,8 +2026,9 @@
 		},
 		"node_modules/glob-to-regexp": {
 			"version": "0.4.1",
-			"dev": true,
-			"license": "BSD-2-Clause"
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+			"dev": true
 		},
 		"node_modules/global-agent": {
 			"version": "3.0.0",
@@ -2080,9 +2114,10 @@
 			}
 		},
 		"node_modules/graceful-fs": {
-			"version": "4.2.10",
-			"dev": true,
-			"license": "ISC"
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true
 		},
 		"node_modules/handle-thing": {
 			"version": "2.0.1",
@@ -2293,9 +2328,10 @@
 			}
 		},
 		"node_modules/http-proxy-middleware": {
-			"version": "2.0.6",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+			"integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@types/http-proxy": "^1.17.8",
 				"http-proxy": "^1.18.1",
@@ -2677,17 +2713,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/matcher": {
 			"version": "3.0.0",
 			"dev": true,
@@ -2743,11 +2768,12 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.5",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"engines": {
@@ -2821,9 +2847,10 @@
 			}
 		},
 		"node_modules/monaco-editor": {
-			"version": "0.32.1",
-			"dev": true,
-			"license": "MIT"
+			"version": "0.52.0",
+			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.0.tgz",
+			"integrity": "sha512-OeWhNpABLCeTqubfqLMXGsqf6OmPU6pHM85kF3dhy6kq5hnhuVS1p3VrEW/XhWHc71P2tHyS5JFySD8mgs1crw==",
+			"dev": true
 		},
 		"node_modules/monaco-editor-webpack-plugin": {
 			"version": "7.0.1",
@@ -2903,9 +2930,10 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.6",
-			"dev": true,
-			"license": "MIT"
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+			"integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+			"dev": true
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -3166,9 +3194,10 @@
 			"dev": true
 		},
 		"node_modules/picocolors": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "ISC"
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -3394,8 +3423,9 @@
 		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -3613,9 +3643,10 @@
 			"dev": true
 		},
 		"node_modules/schema-utils": {
-			"version": "3.1.1",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@types/json-schema": "^7.0.8",
 				"ajv": "^6.12.5",
@@ -3674,12 +3705,10 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.7",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -3739,9 +3768,10 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.0",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
 			"dev": true,
-			"license": "BSD-3-Clause",
 			"dependencies": {
 				"randombytes": "^2.1.0"
 			}
@@ -4154,12 +4184,13 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.14.2",
+			"version": "5.36.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.36.0.tgz",
+			"integrity": "sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w==",
 			"dev": true,
-			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@jridgewell/source-map": "^0.3.2",
-				"acorn": "^8.5.0",
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.8.2",
 				"commander": "^2.20.0",
 				"source-map-support": "~0.5.20"
 			},
@@ -4171,15 +4202,16 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.3.3",
+			"version": "5.3.10",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
+			"integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.7",
+				"@jridgewell/trace-mapping": "^0.3.20",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^3.1.1",
-				"serialize-javascript": "^6.0.0",
-				"terser": "^5.7.2"
+				"serialize-javascript": "^6.0.1",
+				"terser": "^5.26.0"
 			},
 			"engines": {
 				"node": ">= 10.13.0"
@@ -4322,7 +4354,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.5",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+			"integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
 			"dev": true,
 			"funding": [
 				{
@@ -4332,15 +4366,18 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
-			"license": "MIT",
 			"dependencies": {
-				"escalade": "^3.1.1",
-				"picocolors": "^1.0.0"
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.0"
 			},
 			"bin": {
-				"browserslist-lint": "cli.js"
+				"update-browserslist-db": "cli.js"
 			},
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
@@ -4389,9 +4426,10 @@
 			}
 		},
 		"node_modules/watchpack": {
-			"version": "2.4.0",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+			"integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -4409,34 +4447,33 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.76.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
-			"integrity": "sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==",
+			"version": "5.96.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
+			"integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
 			"dev": true,
 			"dependencies": {
-				"@types/eslint-scope": "^3.7.3",
-				"@types/estree": "^0.0.51",
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/wasm-edit": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1",
-				"acorn": "^8.7.1",
-				"acorn-import-assertions": "^1.7.6",
-				"browserslist": "^4.14.5",
+				"@types/eslint-scope": "^3.7.7",
+				"@types/estree": "^1.0.6",
+				"@webassemblyjs/ast": "^1.12.1",
+				"@webassemblyjs/wasm-edit": "^1.12.1",
+				"@webassemblyjs/wasm-parser": "^1.12.1",
+				"acorn": "^8.14.0",
+				"browserslist": "^4.24.0",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.10.0",
-				"es-module-lexer": "^0.9.0",
+				"enhanced-resolve": "^5.17.1",
+				"es-module-lexer": "^1.2.1",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
-				"graceful-fs": "^4.2.9",
+				"graceful-fs": "^4.2.11",
 				"json-parse-even-better-errors": "^2.3.1",
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^3.1.0",
+				"schema-utils": "^3.2.0",
 				"tapable": "^2.1.1",
-				"terser-webpack-plugin": "^5.1.3",
-				"watchpack": "^2.4.0",
+				"terser-webpack-plugin": "^5.3.10",
+				"watchpack": "^2.4.1",
 				"webpack-sources": "^3.2.3"
 			},
 			"bin": {
@@ -4634,11 +4671,6 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/webpack/node_modules/@types/estree": {
-			"version": "0.0.51",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/websocket-driver": {
 			"version": "0.7.4",
 			"dev": true,
@@ -4705,11 +4737,6 @@
 				}
 			}
 		},
-		"node_modules/yallist": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/yaserver": {
 			"version": "0.4.0",
 			"dev": true,
@@ -4761,18 +4788,22 @@
 					"dev": true
 				},
 				"semver": {
-					"version": "6.3.0",
+					"version": "6.3.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 					"dev": true
 				}
 			}
 		},
 		"@jridgewell/gen-mapping": {
-			"version": "0.3.2",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/set-array": "^1.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
 		"@jridgewell/resolve-uri": {
@@ -4780,15 +4811,19 @@
 			"dev": true
 		},
 		"@jridgewell/set-array": {
-			"version": "1.1.2",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
 			"dev": true
 		},
 		"@jridgewell/source-map": {
-			"version": "0.3.2",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+			"integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/gen-mapping": "^0.3.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25"
 			}
 		},
 		"@jridgewell/sourcemap-codec": {
@@ -4796,11 +4831,13 @@
 			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
-			"version": "0.3.14",
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"@leichtgewicht/ip-codec": {
@@ -4859,7 +4896,9 @@
 			}
 		},
 		"@types/eslint": {
-			"version": "8.4.5",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+			"integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "*",
@@ -4867,7 +4906,9 @@
 			}
 		},
 		"@types/eslint-scope": {
-			"version": "3.7.4",
+			"version": "3.7.7",
+			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
 			"dev": true,
 			"requires": {
 				"@types/eslint": "*",
@@ -4875,7 +4916,9 @@
 			}
 		},
 		"@types/estree": {
-			"version": "1.0.0",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
 			"dev": true
 		},
 		"@types/express": {
@@ -4996,118 +5039,148 @@
 			}
 		},
 		"@webassemblyjs/ast": {
-			"version": "1.11.1",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+			"integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/helper-numbers": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+				"@webassemblyjs/helper-numbers": "1.13.2",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2"
 			}
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.11.1",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+			"integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-api-error": {
-			"version": "1.11.1",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+			"integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-buffer": {
-			"version": "1.11.1",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+			"integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-numbers": {
-			"version": "1.11.1",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+			"integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
-				"@webassemblyjs/helper-api-error": "1.11.1",
+				"@webassemblyjs/floating-point-hex-parser": "1.13.2",
+				"@webassemblyjs/helper-api-error": "1.13.2",
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.11.1",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+			"integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-wasm-section": {
-			"version": "1.11.1",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+			"integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1"
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-buffer": "1.14.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/wasm-gen": "1.14.1"
 			}
 		},
 		"@webassemblyjs/ieee754": {
-			"version": "1.11.1",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+			"integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
 			"dev": true,
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
-			"version": "1.11.1",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+			"integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
 			"dev": true,
 			"requires": {
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/utf8": {
-			"version": "1.11.1",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+			"integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
 			"dev": true
 		},
 		"@webassemblyjs/wasm-edit": {
-			"version": "1.11.1",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+			"integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/helper-wasm-section": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1",
-				"@webassemblyjs/wasm-opt": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1",
-				"@webassemblyjs/wast-printer": "1.11.1"
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-buffer": "1.14.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/helper-wasm-section": "1.14.1",
+				"@webassemblyjs/wasm-gen": "1.14.1",
+				"@webassemblyjs/wasm-opt": "1.14.1",
+				"@webassemblyjs/wasm-parser": "1.14.1",
+				"@webassemblyjs/wast-printer": "1.14.1"
 			}
 		},
 		"@webassemblyjs/wasm-gen": {
-			"version": "1.11.1",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+			"integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/ieee754": "1.11.1",
-				"@webassemblyjs/leb128": "1.11.1",
-				"@webassemblyjs/utf8": "1.11.1"
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/ieee754": "1.13.2",
+				"@webassemblyjs/leb128": "1.13.2",
+				"@webassemblyjs/utf8": "1.13.2"
 			}
 		},
 		"@webassemblyjs/wasm-opt": {
-			"version": "1.11.1",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+			"integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-buffer": "1.11.1",
-				"@webassemblyjs/wasm-gen": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1"
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-buffer": "1.14.1",
+				"@webassemblyjs/wasm-gen": "1.14.1",
+				"@webassemblyjs/wasm-parser": "1.14.1"
 			}
 		},
 		"@webassemblyjs/wasm-parser": {
-			"version": "1.11.1",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+			"integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/helper-api-error": "1.11.1",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-				"@webassemblyjs/ieee754": "1.11.1",
-				"@webassemblyjs/leb128": "1.11.1",
-				"@webassemblyjs/utf8": "1.11.1"
+				"@webassemblyjs/ast": "1.14.1",
+				"@webassemblyjs/helper-api-error": "1.13.2",
+				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+				"@webassemblyjs/ieee754": "1.13.2",
+				"@webassemblyjs/leb128": "1.13.2",
+				"@webassemblyjs/utf8": "1.13.2"
 			}
 		},
 		"@webassemblyjs/wast-printer": {
-			"version": "1.11.1",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+			"integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/ast": "1.14.1",
 				"@xtuc/long": "4.2.2"
 			}
 		},
@@ -5130,10 +5203,14 @@
 		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
 			"dev": true
 		},
 		"@xtuc/long": {
 			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true
 		},
 		"accepts": {
@@ -5145,13 +5222,10 @@
 			}
 		},
 		"acorn": {
-			"version": "8.8.0",
+			"version": "8.14.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
 			"dev": true
-		},
-		"acorn-import-assertions": {
-			"version": "1.8.0",
-			"dev": true,
-			"requires": {}
 		},
 		"ajv": {
 			"version": "8.11.0",
@@ -5283,13 +5357,15 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.21.3",
+			"version": "4.24.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+			"integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001370",
-				"electron-to-chromium": "^1.4.202",
-				"node-releases": "^2.0.6",
-				"update-browserslist-db": "^1.0.5"
+				"caniuse-lite": "^1.0.30001669",
+				"electron-to-chromium": "^1.5.41",
+				"node-releases": "^2.0.18",
+				"update-browserslist-db": "^1.1.1"
 			}
 		},
 		"buffer-crc32": {
@@ -5356,7 +5432,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001375",
+			"version": "1.0.30001684",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001684.tgz",
+			"integrity": "sha512-G1LRwLIQjBQoyq0ZJGqGIJUXzJ8irpbjHLpVRXDvBEScFJ9b17sgK6vlx0GAJFE21okD7zXl08rRRUfq6HdoEQ==",
 			"dev": true
 		},
 		"chalk": {
@@ -5502,9 +5580,9 @@
 			"dev": true
 		},
 		"cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+			"integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
 			"dev": true
 		},
 		"cookie-signature": {
@@ -5516,7 +5594,9 @@
 			"dev": true
 		},
 		"cross-spawn": {
-			"version": "7.0.3",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"requires": {
 				"path-key": "^3.1.0",
@@ -5705,7 +5785,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.215",
+			"version": "1.5.64",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.64.tgz",
+			"integrity": "sha512-IXEuxU+5ClW2IGEYFC2T7szbyVgehupCWQe5GNh+H065CD6U6IFN0s4KeAMFGNmQolRU4IV7zGBWSYMmZ8uuqQ==",
 			"dev": true
 		},
 		"emojis-list": {
@@ -5724,7 +5806,9 @@
 			}
 		},
 		"enhanced-resolve": {
-			"version": "5.10.0",
+			"version": "5.17.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+			"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.2.4",
@@ -5759,7 +5843,9 @@
 			"dev": true
 		},
 		"es-module-lexer": {
-			"version": "0.9.3",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
+			"integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
 			"dev": true
 		},
 		"es6-error": {
@@ -5768,7 +5854,9 @@
 			"optional": true
 		},
 		"escalade": {
-			"version": "3.1.1",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"dev": true
 		},
 		"escape-html": {
@@ -5835,9 +5923,9 @@
 			}
 		},
 		"express": {
-			"version": "4.21.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-			"integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+			"version": "4.21.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+			"integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
 			"dev": true,
 			"requires": {
 				"accepts": "~1.3.8",
@@ -5845,7 +5933,7 @@
 				"body-parser": "1.20.3",
 				"content-disposition": "0.5.4",
 				"content-type": "~1.0.4",
-				"cookie": "0.6.0",
+				"cookie": "0.7.1",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
@@ -6077,6 +6165,8 @@
 		},
 		"glob-to-regexp": {
 			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
 			"dev": true
 		},
 		"global-agent": {
@@ -6138,7 +6228,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.10",
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true
 		},
 		"handle-thing": {
@@ -6279,7 +6371,9 @@
 			}
 		},
 		"http-proxy-middleware": {
-			"version": "2.0.6",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+			"integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
 			"dev": true,
 			"requires": {
 				"@types/http-proxy": "^1.17.8",
@@ -6514,13 +6608,6 @@
 			"version": "2.0.0",
 			"dev": true
 		},
-		"lru-cache": {
-			"version": "6.0.0",
-			"dev": true,
-			"requires": {
-				"yallist": "^4.0.0"
-			}
-		},
 		"matcher": {
 			"version": "3.0.0",
 			"dev": true,
@@ -6557,10 +6644,12 @@
 			"dev": true
 		},
 		"micromatch": {
-			"version": "4.0.5",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
 			"requires": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			}
 		},
@@ -6601,7 +6690,9 @@
 			}
 		},
 		"monaco-editor": {
-			"version": "0.32.1",
+			"version": "0.52.0",
+			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.0.tgz",
+			"integrity": "sha512-OeWhNpABLCeTqubfqLMXGsqf6OmPU6pHM85kF3dhy6kq5hnhuVS1p3VrEW/XhWHc71P2tHyS5JFySD8mgs1crw==",
 			"dev": true
 		},
 		"monaco-editor-webpack-plugin": {
@@ -6650,7 +6741,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "2.0.6",
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+			"integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
 			"dev": true
 		},
 		"normalize-path": {
@@ -6814,7 +6907,9 @@
 			"dev": true
 		},
 		"picocolors": {
-			"version": "1.0.0",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
 			"dev": true
 		},
 		"picomatch": {
@@ -6946,6 +7041,8 @@
 		},
 		"randombytes": {
 			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
@@ -7089,7 +7186,9 @@
 			"dev": true
 		},
 		"schema-utils": {
-			"version": "3.1.1",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.8",
@@ -7130,11 +7229,10 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.7",
-			"dev": true,
-			"requires": {
-				"lru-cache": "^6.0.0"
-			}
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true
 		},
 		"semver-compare": {
 			"version": "1.0.0",
@@ -7179,7 +7277,9 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "6.0.0",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
 			"dev": true,
 			"requires": {
 				"randombytes": "^2.1.0"
@@ -7466,11 +7566,13 @@
 			"dev": true
 		},
 		"terser": {
-			"version": "5.14.2",
+			"version": "5.36.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.36.0.tgz",
+			"integrity": "sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/source-map": "^0.3.2",
-				"acorn": "^8.5.0",
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.8.2",
 				"commander": "^2.20.0",
 				"source-map-support": "~0.5.20"
 			},
@@ -7482,14 +7584,16 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "5.3.3",
+			"version": "5.3.10",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
+			"integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/trace-mapping": "^0.3.7",
+				"@jridgewell/trace-mapping": "^0.3.20",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^3.1.1",
-				"serialize-javascript": "^6.0.0",
-				"terser": "^5.7.2"
+				"serialize-javascript": "^6.0.1",
+				"terser": "^5.26.0"
 			}
 		},
 		"thunky": {
@@ -7562,11 +7666,13 @@
 			"dev": true
 		},
 		"update-browserslist-db": {
-			"version": "1.0.5",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+			"integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
 			"dev": true,
 			"requires": {
-				"escalade": "^3.1.1",
-				"picocolors": "^1.0.0"
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.0"
 			}
 		},
 		"uri-js": {
@@ -7597,7 +7703,9 @@
 			"dev": true
 		},
 		"watchpack": {
-			"version": "2.4.0",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+			"integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
 			"dev": true,
 			"requires": {
 				"glob-to-regexp": "^0.4.1",
@@ -7612,41 +7720,34 @@
 			}
 		},
 		"webpack": {
-			"version": "5.76.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
-			"integrity": "sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==",
+			"version": "5.96.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
+			"integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
 			"dev": true,
 			"requires": {
-				"@types/eslint-scope": "^3.7.3",
-				"@types/estree": "^0.0.51",
-				"@webassemblyjs/ast": "1.11.1",
-				"@webassemblyjs/wasm-edit": "1.11.1",
-				"@webassemblyjs/wasm-parser": "1.11.1",
-				"acorn": "^8.7.1",
-				"acorn-import-assertions": "^1.7.6",
-				"browserslist": "^4.14.5",
+				"@types/eslint-scope": "^3.7.7",
+				"@types/estree": "^1.0.6",
+				"@webassemblyjs/ast": "^1.12.1",
+				"@webassemblyjs/wasm-edit": "^1.12.1",
+				"@webassemblyjs/wasm-parser": "^1.12.1",
+				"acorn": "^8.14.0",
+				"browserslist": "^4.24.0",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.10.0",
-				"es-module-lexer": "^0.9.0",
+				"enhanced-resolve": "^5.17.1",
+				"es-module-lexer": "^1.2.1",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
-				"graceful-fs": "^4.2.9",
+				"graceful-fs": "^4.2.11",
 				"json-parse-even-better-errors": "^2.3.1",
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^3.1.0",
+				"schema-utils": "^3.2.0",
 				"tapable": "^2.1.1",
-				"terser-webpack-plugin": "^5.1.3",
-				"watchpack": "^2.4.0",
+				"terser-webpack-plugin": "^5.3.10",
+				"watchpack": "^2.4.1",
 				"webpack-sources": "^3.2.3"
-			},
-			"dependencies": {
-				"@types/estree": {
-					"version": "0.0.51",
-					"dev": true
-				}
 			}
 		},
 		"webpack-cli": {
@@ -7785,10 +7886,6 @@
 			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
 			"dev": true,
 			"requires": {}
-		},
-		"yallist": {
-			"version": "4.0.0",
-			"dev": true
 		},
 		"yaserver": {
 			"version": "0.4.0",

--- a/samples/package.json
+++ b/samples/package.json
@@ -16,7 +16,7 @@
 		"glob": "^7.2.0",
 		"html-webpack-plugin": "^5.5.0",
 		"monaco-editor-webpack-plugin": "^7.0.1",
-		"monaco-editor": "^0.32.1",
+		"monaco-editor": "^0.52.0",
 		"style-loader": "^3.3.1",
 		"terser-webpack-plugin": "^5.3.1",
 		"ts-loader": "^9.2.6",


### PR DESCRIPTION
The samples included in monaco-editor were configured to use release `0.32.1`. After changing this to `0.52.0` in `package.json`, `npm audit` noted 7 vulnerabilities (2 low, 2 moderate, 3 high). Audit fix removed 4 packages, changed 50 packages, and audited 443 packages. This is reflected in `package-lock.json`.