### PR TITLE
Split typescriptService.js into separate module

### DIFF
--- a/build/build-languages.ts
+++ b/build/build-languages.ts
@@ -136,9 +136,10 @@ buildESM({
 	entryPoints: [
 		'src/language/typescript/monaco.contribution.ts',
 		'src/language/typescript/tsMode.ts',
-		'src/language/typescript/ts.worker.ts'
+		'src/language/typescript/ts.worker.ts',
+		'src/language/typescript/lib/typescriptServices.js'
 	],
-	external: ['monaco-editor-core', '*/tsMode', '*/monaco.contribution']
+	external: ['monaco-editor-core', '*/tsMode', '*/monaco.contribution', '*/lib/typescriptServices']
 });
 buildAMD({
 	base: 'language/typescript',


### PR DESCRIPTION
Firefox addons have a hard limit of 4MB per JS file. The existing ts.worker.ts file can only be minified down to 5.6M.

This change splits the vendored typescript library into a separate module to make code-splitting possible.