### PR TITLE
Expose getEncodedSemanticClassifications from TypeScript

### DIFF
--- a/src/language/typescript/monaco.contribution.ts
+++ b/src/language/typescript/monaco.contribution.ts
@@ -547,6 +547,18 @@ export interface TypeScriptWorker {
 	 * @returns `Promise<typescript.InlayHint[]>`
 	 */
 	provideInlayHints(fileName: string, start: number, end: number): Promise<ReadonlyArray<any>>;
+
+	/**
+	 * Get encoded semantic classifications in the range of the file.
+	 *
+	 * The returned number array is encoded as triples of [start, length, ClassificationType, ...].
+	 * @returns `Promise<typescript.Classifications | undefined>`
+	 */
+	getEncodedSemanticClassifications(
+		fileName: string,
+		start: number,
+		end: number
+	): Promise<{ spans: number[] } | undefined>;
 }
 
 // --- TypeScript configuration and defaults ---------

--- a/src/language/typescript/tsWorker.ts
+++ b/src/language/typescript/tsWorker.ts
@@ -473,6 +473,21 @@ export class TypeScriptWorker implements ts.LanguageServiceHost, ITypeScriptWork
 			return [];
 		}
 	}
+
+	async getEncodedSemanticClassifications(
+		fileName: string,
+		start: number,
+		end: number
+	): Promise<ts.Classifications | undefined> {
+		if (fileNameIsLib(fileName)) {
+			return undefined;
+		}
+		return this._languageService.getEncodedSemanticClassifications(
+			fileName,
+			{ start, length: end - start },
+			'2020' as ts.SemanticClassificationFormat
+		);
+	}
 }
 
 export interface ICreateData {


### PR DESCRIPTION
Currently, there's no way to get semantic token information for TypeScript from monaco (#2872)

However, the functionality is readily available inside TypeScript.

This PR exposes `getEncodedSemanticClassifications` from TypeScript via TypeScriptWorker to unblock user-land implementation of better TS highlighting.

