### PR TITLE
Prevents injecting Node.js globals like `process`, which can break browser features (e.g., Mac `Cmd` key) when loading from ESM-based CDN like esm.sh.

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,5 +77,9 @@
 	"alias": {
 		"process": false,
 		"buffer": false
+	},
+	"browser": {
+		"process": false,
+		"buffer": false
 	}
 }


### PR DESCRIPTION
If monaco-editor is loaded from ESM based CDNs, shortcuts which contain `Cmd` will not works on Mac and instead you should use `Ctrl` even you are using mac device

see https://esm.sh/monaco-editor

```
/* esm.sh - monaco-editor@0.52.2 */
import "/node/buffer.mjs";
import "/node/process.mjs";
export * from "/monaco-editor@0.52.2/es2022/monaco-editor.mjs";
```

where buffer and process are polyfilled

ref https://github.com/esm-dev/esm.sh/issues/1134#issuecomment-2870426164