### PR TITLE
Fix Kotlin number literals

### DIFF
--- a/src/basic-languages/kotlin/kotlin.test.ts
+++ b/src/basic-languages/kotlin/kotlin.test.ts
@@ -279,6 +279,13 @@ testTokenization('kotlin', [
 
 	[
 		{
+			line: '.123',
+			tokens: [{ startIndex: 0, type: 'number.float.kt' }]
+		}
+	],
+
+	[
+		{
 			line: '0x',
 			tokens: [
 				{ startIndex: 0, type: 'number.kt' },
@@ -303,22 +310,60 @@ testTokenization('kotlin', [
 
 	[
 		{
+			line: '0Xff_81_00L',
+			tokens: [{ startIndex: 0, type: 'number.hex.kt' }]
+		}
+	],
+
+	[
+		{
+			line: '0x123u',
+			tokens: [{ startIndex: 0, type: 'number.hex.kt' }]
+		}
+	],
+
+	[
+		{
+			line: '0x123U',
+			tokens: [{ startIndex: 0, type: 'number.hex.kt' }]
+		}
+	],
+
+	[
+		{
+			line: '0x123uL',
+			tokens: [{ startIndex: 0, type: 'number.hex.kt' }]
+		}
+	],
+
+	[
+		{
+			line: '0x123UL',
+			tokens: [{ startIndex: 0, type: 'number.hex.kt' }]
+		}
+	],
+
+	[
+		{
 			line: '023L',
-			tokens: [{ startIndex: 0, type: 'number.octal.kt' }]
+			tokens: [{ startIndex: 0, type: 'number.kt' }]
 		}
 	],
 
 	[
 		{
 			line: '0123l',
-			tokens: [{ startIndex: 0, type: 'number.octal.kt' }]
+			tokens: [
+				{ startIndex: 0, type: 'number.kt' },
+				{ startIndex: 4, type: 'identifier.kt' }
+			]
 		}
 	],
 
 	[
 		{
 			line: '05_2',
-			tokens: [{ startIndex: 0, type: 'number.octal.kt' }]
+			tokens: [{ startIndex: 0, type: 'number.kt' }]
 		}
 	],
 
@@ -332,6 +377,41 @@ testTokenization('kotlin', [
 	[
 		{
 			line: '0B001',
+			tokens: [{ startIndex: 0, type: 'number.binary.kt' }]
+		}
+	],
+
+	[
+		{
+			line: '0b0101L',
+			tokens: [{ startIndex: 0, type: 'number.binary.kt' }]
+		}
+	],
+
+	[
+		{
+			line: '0B0101u',
+			tokens: [{ startIndex: 0, type: 'number.binary.kt' }]
+		}
+	],
+
+	[
+		{
+			line: '0B1__0U',
+			tokens: [{ startIndex: 0, type: 'number.binary.kt' }]
+		}
+	],
+
+	[
+		{
+			line: '0B0101uL',
+			tokens: [{ startIndex: 0, type: 'number.binary.kt' }]
+		}
+	],
+
+	[
+		{
+			line: '0B1__0UL',
 			tokens: [{ startIndex: 0, type: 'number.binary.kt' }]
 		}
 	],
@@ -401,57 +481,88 @@ testTokenization('kotlin', [
 
 	[
 		{
-			line: '23.5D',
+			line: '.001f',
 			tokens: [{ startIndex: 0, type: 'number.float.kt' }]
+		}
+	],
+
+	[
+		{
+			line: '23.5D',
+			tokens: [
+				{ startIndex: 0, type: 'number.float.kt' },
+				{ startIndex: 4, type: 'type.identifier.kt' }
+			]
 		}
 	],
 
 	[
 		{
 			line: '23.5d',
-			tokens: [{ startIndex: 0, type: 'number.float.kt' }]
+			tokens: [
+				{ startIndex: 0, type: 'number.float.kt' },
+				{ startIndex: 4, type: 'identifier.kt' }
+			]
 		}
 	],
 
 	[
 		{
 			line: '1.72E3D',
-			tokens: [{ startIndex: 0, type: 'number.float.kt' }]
+			tokens: [
+				{ startIndex: 0, type: 'number.float.kt' },
+				{ startIndex: 6, type: 'type.identifier.kt' }
+			]
 		}
 	],
 
 	[
 		{
 			line: '1.72E3d',
-			tokens: [{ startIndex: 0, type: 'number.float.kt' }]
+			tokens: [
+				{ startIndex: 0, type: 'number.float.kt' },
+				{ startIndex: 6, type: 'identifier.kt' }
+			]
 		}
 	],
 
 	[
 		{
 			line: '1.72E-3d',
-			tokens: [{ startIndex: 0, type: 'number.float.kt' }]
+			tokens: [
+				{ startIndex: 0, type: 'number.float.kt' },
+				{ startIndex: 7, type: 'identifier.kt' }
+			]
 		}
 	],
 
 	[
 		{
 			line: '1.72e3D',
-			tokens: [{ startIndex: 0, type: 'number.float.kt' }]
+			tokens: [
+				{ startIndex: 0, type: 'number.float.kt' },
+				{ startIndex: 6, type: 'type.identifier.kt' }
+			]
 		}
 	],
 
 	[
 		{
 			line: '1.72e3d',
-			tokens: [{ startIndex: 0, type: 'number.float.kt' }]
+			tokens: [
+				{ startIndex: 0, type: 'number.float.kt' },
+				{ startIndex: 6, type: 'identifier.kt' }
+			]
 		}
 	],
 
 	[
 		{
 			line: '1.72e-3d',
-			tokens: [{ startIndex: 0, type: 'number.float.kt' }]
+			tokens: [
+				{ startIndex: 0, type: 'number.float.kt' },
+				{ startIndex: 7, type: 'identifier.kt' }
+			]
 		}
 	],
 
@@ -465,6 +576,37 @@ testTokenization('kotlin', [
 	[
 		{
 			line: '23l',
+			tokens: [
+				{ startIndex: 0, type: 'number.kt' },
+				{ startIndex: 2, type: 'identifier.kt' }
+			]
+		}
+	],
+
+	[
+		{
+			line: '23u',
+			tokens: [{ startIndex: 0, type: 'number.kt' }]
+		}
+	],
+
+	[
+		{
+			line: '23U',
+			tokens: [{ startIndex: 0, type: 'number.kt' }]
+		}
+	],
+
+	[
+		{
+			line: '23uL',
+			tokens: [{ startIndex: 0, type: 'number.kt' }]
+		}
+	],
+
+	[
+		{
+			line: '23UL',
 			tokens: [{ startIndex: 0, type: 'number.kt' }]
 		}
 	],
@@ -496,8 +638,7 @@ testTokenization('kotlin', [
 			tokens: [
 				{ startIndex: 0, type: 'number.kt' },
 				{ startIndex: 1, type: 'identifier.kt' },
-				{ startIndex: 2, type: 'delimiter.kt' },
-				{ startIndex: 3, type: 'number.float.kt' }
+				{ startIndex: 2, type: 'number.float.kt' }
 			]
 		}
 	],
@@ -567,7 +708,7 @@ testTokenization('kotlin', [
 		{
 			line: '052_',
 			tokens: [
-				{ startIndex: 0, type: 'number.octal.kt' },
+				{ startIndex: 0, type: 'number.kt' },
 				{ startIndex: 3, type: 'identifier.kt' }
 			]
 		}

--- a/src/basic-languages/kotlin/kotlin.ts
+++ b/src/basic-languages/kotlin/kotlin.ts
@@ -211,13 +211,12 @@ export const language = <languages.IMonarchLanguage>{
 			[/@\s*[a-zA-Z_\$][\w\$]*/, 'annotation'],
 
 			// numbers
-			[/(@digits)[eE]([\-+]?(@digits))?[fFdD]?/, 'number.float'],
-			[/(@digits)\.(@digits)([eE][\-+]?(@digits))?[fFdD]?/, 'number.float'],
-			[/0[xX](@hexdigits)[Ll]?/, 'number.hex'],
-			[/0(@octaldigits)[Ll]?/, 'number.octal'],
-			[/0[bB](@binarydigits)[Ll]?/, 'number.binary'],
-			[/(@digits)[fFdD]/, 'number.float'],
-			[/(@digits)[lL]?/, 'number'],
+			[/(@digits)[eE]([\-+]?(@digits))?[fF]?/, 'number.float'],
+			[/(@digits)?\.(@digits)([eE][\-+]?(@digits))?[fF]?/, 'number.float'],
+			[/0[xX](@hexdigits)[uU]?L?/, 'number.hex'],
+			[/0[bB](@binarydigits)[uU]?L?/, 'number.binary'],
+			[/(@digits)[fF]/, 'number.float'],
+			[/(@digits)[uU]?L?/, 'number'],
 
 			// delimiter: after number because of .\d floats
 			[/[;,.]/, 'delimiter'],


### PR DESCRIPTION
There were a couple of problems in Kotlins number literal parsing.
This PR adapts it to conform to the grammar described in the [Language Spec](https://kotlinlang.org/spec/pdf/kotlin-spec.pdf) chapter _1.2.3 Literals_.

### Unsigned suffixes

In Kotlin 1.5 unsigned numbers were introduced, including the suffixes `u` and `U` for number literals and while the following examples are valid Kotlin now they weren't correctly highlighted:

```kotlin
val u1 = 123u
val u2 = 123U
val u3 = 123uL
val u4 = 0b0101UL
val u5 = 0Xff0088u
```


### Leading dot floating point literals

In Kotlin number literals can start with a leading dot.

```kotlin
val f1 = .1
val f2 = .123
val f3 = .123e+12f
```


### Long suffix must be uppercase
Unlike Java only the uppercase `L` is a valid suffix.

```kotlin
// Valid
val correct = 123L

// Error:  Use 'L' instead of 'l'.
val wrong = 123l
```

### Double suffix doesn't exist

Unlike Java there isn't a suffix to indicate that a number is a double.

```kotlin
// Valid
val correct = 123L

// Error
val wrong1 = 123D
val wrong1 = 123d
```