### PR TITLE
Fixes https://github.com/microsoft/monaco-editor/issues/4906

### DIFF
--- a/scripts/lib/index.ts
+++ b/scripts/lib/index.ts
@@ -92,4 +92,5 @@ export interface PackageJson {
 	vscodeCommitId?: string;
 	monacoCommitId?: string;
 	devDependencies: Record<string, string>;
+	dependencies?: Record<string, string>;
 }


### PR DESCRIPTION
Copies over dependencies from monaco-editor-core (which is dompurify and marked).
The versions are specific and npm ci runs before the package is updated, so that no unexpected code will be run.
