### PR TITLE
Fix a11y color contrast bug in sample

### DIFF
--- a/website/src/website/data/playground-samples/customizing-the-appearence/tokens-and-colors/sample.js
+++ b/website/src/website/data/playground-samples/customizing-the-appearence/tokens-and-colors/sample.js
@@ -15,7 +15,7 @@ monaco.editor.defineTheme("myCustomTheme", {
 	rules: [
 		{
 			token: "comment",
-			foreground: "ffa500",
+			foreground: "a80085",
 			fontStyle: "italic underline",
 		},
 		{ token: "comment.js", foreground: "008800", fontStyle: "bold" },


### PR DESCRIPTION
Resolves https://github.com/microsoft/monaco-editor/issues/5074

Updates Colors and Tokens sample to use a comment color (from yellow to dark pink) that meets a11y color contrast requirements.