### PR TITLE
Fix web components sample

### DIFF
--- a/website/src/website/data/playground-samples/creating-the-editor/web-component/sample.js
+++ b/website/src/website/data/playground-samples/creating-the-editor/web-component/sample.js
@@ -12,7 +12,7 @@ customElements.define(
 
 			// Copy over editor styles
 			const styles = document.querySelectorAll(
-				"link[rel='stylesheet'][data-name^='vs/']"
+				"link[rel='stylesheet'][href*='monaco-editor']"
 			);
 			for (const style of styles) {
 				shadowRoot.appendChild(style.cloneNode(true));


### PR DESCRIPTION
Fixes https://github.com/microsoft/monaco-editor/issues/5145

I'm not sure this a perfect sample, as it assumes the consumer imports the `editor.main.css` file, 

It seems vs code will add the css within the each module, so some of the styles will get declared twice:
https://github.com/microsoft/vscode/blob/e78d8b50851b6cf3c427c2078b6238446f06beff/src/vs/base/browser/ui/actionbar/actionbar.ts#L15-L18

But I think a sample attempting to copy the css from that mechanism into the shadow DOM would be too complicated.