### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,17 @@ jobs:
     name: CI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 
       - name: Cache node modules
         id: cacheNodeModules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-cacheNodeModules2-${{ hashFiles('**/package-lock.json', '**/package.json') }}
@@ -103,7 +103,7 @@ jobs:
         run: npm run test
 
       - name: Upload website artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: website
           path: ./website/dist

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -25,13 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
       - name: Cache node modules
         id: cacheNodeModules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-cacheNodeModules2-${{ hashFiles('**/package-lock.json') }}
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           # Upload entire repository
           path: './website/dist'


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/cache` from `v4` to `v5` in `.github/workflows/website.yml`
- Updated `actions/cache` from `v4` to `v5` in `.github/workflows/ci.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/ci.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/website.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/ci.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/website.yml`
- Updated `actions/upload-pages-artifact` from `v3` to `v4` in `.github/workflows/website.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/ci.yml`
