### PR TITLE
Update liquid.ts elseif -> elsif

### DIFF
--- a/src/languages/definitions/liquid/liquid.ts
+++ b/src/languages/definitions/liquid/liquid.ts
@@ -79,7 +79,7 @@ export const language = <languages.IMonarchLanguage>{
 	builtinTags: [
 		'if',
 		'else',
-		'elseif',
+		'elsif',
 		'endif',
 		'render',
 		'assign',


### PR DESCRIPTION
in liquidjs/shopify it is 'elsif' and not 'elseif'.

https://shopify.dev/docs/api/liquid/tags/if#else-elsif 
https://liquidjs.com/tags/if.html