### PR TITLE
[LSP] Preserve document URI as is for text document management

### DIFF
--- a/monaco-lsp-client/src/adapters/TextDocumentSynchronizer.ts
+++ b/monaco-lsp-client/src/adapters/TextDocumentSynchronizer.ts
@@ -53,7 +53,7 @@ export class TextDocumentSynchronizer extends Disposable implements ITextModelBr
             throw new Error('Not started');
         }
 
-        const uriStr = m.uri.toString(true).toLowerCase();
+        const uriStr = m.uri.toString(true);
         let mm = this._managedModels.get(m);
         if (!mm) {
             mm = new ManagedModel(m, this._server);
@@ -69,7 +69,7 @@ export class TextDocumentSynchronizer extends Disposable implements ITextModelBr
     }
 
     translateBack(textDocument: TextDocumentIdentifier, position: Position): { textModel: monaco.editor.ITextModel; position: monaco.Position; } {
-        const uri = textDocument.uri.toLowerCase();
+        const uri = textDocument.uri;
         const textModel = this._managedModelsReverse.get(uri);
         if (!textModel) {
             throw new Error(`No text model for uri ${uri}`);
@@ -79,7 +79,7 @@ export class TextDocumentSynchronizer extends Disposable implements ITextModelBr
     }
 
     translateBackRange(textDocument: TextDocumentIdentifier, range: Range): { textModel: monaco.editor.ITextModel; range: monaco.Range; } {
-        const uri = textDocument.uri.toLowerCase();
+        const uri = textDocument.uri;
         const textModel = this._managedModelsReverse.get(uri);
         if (!textModel) {
             throw new Error(`No text model for uri ${uri}`);
@@ -126,7 +126,7 @@ class ManagedModel extends Disposable {
     ) {
         super();
 
-        const uri = _textModel.uri.toString(true).toLowerCase();
+        const uri = _textModel.uri.toString(true);
 
         this._api.textDocumentDidOpen({
             textDocument: {


### PR DESCRIPTION
According to the [language server protocol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#uri) and the corresponding [RFC 3986 for URIs](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.1), the scheme and host are case-insensitive and other generic syntax components are assumed to be case-sensitive.

Fixes https://github.com/microsoft/monaco-editor/issues/5224