### PR TITLE
docs: remove duplicate word in maintaining notes

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -15,7 +15,7 @@ Make sure every unassigned issue is labeled properly:
     - Use `rc` for `The prerelease version.`
   - Wait until pipeline completes
 - [Compare Last Stable With Nightly](https://microsoft.github.io/monaco-editor/playground.html?source=v0.40.0-dev.20230704#XQAAAAIGBwAAAAAAAABBqQkHQ5NjdMjwa-jY7SIQ9S7DNlzs5W-mwj0fe1ZCDRFc9ws9XQE0SJE1jc2VKxhaLFIw9vEWSxW3yscxAWG5G70rT-mLieOxDi0igaBcv2nRy9q6wT9hrC3N47TPeSd0URO3iwn_firHxVGLm2_8QMEuG2aOJ-jnXkHfLAawVi9XJdfEkOLYHqAT78XFdClh7HNBHFpSfLkCNQ3vE811FAdf6WYL_UK2n1jfGRMcnWqaztoAOTcWNn5qQ9RusryNfDBRqtjOJktItFKSNuOcLg104A0xatH8uXcfAULeE9RZRf41YqC9wbcZDEp7Mnul26YzW_IBv-vL-EGPcEFiu34YZPHQguQiuU8L4VXh7uAtKRWehN9N2m2XFF3yHCBpSGiN8qmBi4HSBRjbhkEKka_icj87t3Lfmg15PMqKgTr7l73XusvkQCZDvqumlN-mcVTZiIdD51m-OFugmn0Cq_ZPU2zq45rRtk1he8PcWiZpPSbCknJsHs4D-mKcc-ypq6CLYlqO8Cvc5lRWzwD-pG6e6uPAQsRAOJ45-mySqhRo_MGJ7aLfkhe7fVn9OvOm6BRsDAYmNVZqpA5aKJzwjeUwQqHwV8CW-b4hrZooiPavu8m2XgbiSW_5nmzbjQ-SaPnBsJxcAewWB_NiYiU3H_Gfhi8K0qQZlBxaetqYX5Ns1Ww6S_By4izRxeEln7McyDQxKk-tnywSCklMhZPiMaR0AZsXs5DQSxGTlB5q61e7Wtxb0RLdk5einYvNwXDooi5Vi5go_ZsO7JYmzylxi-T_hdsPgKNoy6j9IVh5BZb_HgRoaGCrojOWJdYpNNrPJJG_1fyZ8Bk80eYNmHHPJ7Q-pdXqQuAZBdd9Grv4UfXoY1R3Sl529QkIjEHTzgzYGn4C5KE5IGhEfu49Ugy0fFHU-yJGY__aPECJ)
-  - Check the metadata and verify that the last stable is on the left and the the last rc build is on the right
+  - Check the metadata and verify that the last stable is on the left and the last rc build is on the right
 - Update [package.json](./package.json)
   - set `version` to _lastNightly.nextStableVersion_ (from the compare step)
   - set `vscodeRef` to _lastNightly.vscodeCommitId_


### PR DESCRIPTION
## Summary\n- remove a duplicate word in MAINTAINING instructions\n\n## Related issue\n- N/A\n\n## Guideline alignment\n- https://github.com/microsoft/monaco-editor/blob/main/CONTRIBUTING.md\n\n## Validation\n- Not run (doc-only change)