### PR TITLE
docs: fix parcel worker typo

### DIFF
--- a/docs/integrate-esm.md
+++ b/docs/integrate-esm.md
@@ -136,7 +136,7 @@ module.exports = {
 
 A full working sample is available at https://github.com/microsoft/monaco-editor/tree/main/samples/browser-esm-parcel
 
-When using parcel, we need to use the `getWorkerUrl` function and build the workers seperately from our main source. To simplify things, we can write a tiny bash script to build the workers for us.
+When using parcel, we need to use the `getWorkerUrl` function and build the workers separately from our main source. To simplify things, we can write a tiny bash script to build the workers for us.
 
 - `index.js`
 


### PR DESCRIPTION
## Summary
- Fixes a typo in the ESM integration guide.
- Changes `seperately` to `separately`.

## Related issue
N/A (trivial docs typo fix)

## Guideline alignment
- https://github.com/microsoft/monaco-editor/blob/main/CONTRIBUTING.md
- One focused docs change in one file.
- No behavior changes.

## Validation
- Not run (documentation-only change).
