### PR TITLE
Revert "Bump dompurify from 3.2.7 to 3.4.5"

### DIFF
--- a/monaco-lsp-client/package-lock.json
+++ b/monaco-lsp-client/package-lock.json
@@ -1038,9 +1038,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
-			"integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+			"integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"peer": true,
 			"optionalDependencies": {
@@ -1314,7 +1314,7 @@
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"dompurify": "3.4.5",
+				"dompurify": "3.2.7",
 				"marked": "14.0.0"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -5172,14 +5172,22 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
-			"integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+			"integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
 			"dev": true,
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
 			}
+		},
+		"node_modules/dompurify/node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/dotenv": {
 			"version": "16.6.1",
@@ -7140,7 +7148,7 @@
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"dompurify": "3.4.5",
+				"dompurify": "3.2.7",
 				"marked": "14.0.0"
 			}
 		},
@@ -10730,14 +10738,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/dompurify/node_modules/@types/trusted-types": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true
 		}
 	},
 	"dependencies": {
@@ -13734,9 +13734,9 @@
 			"dev": true
 		},
 		"dompurify": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
-			"integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+			"integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
 			"dev": true,
 			"requires": {
 				"@types/trusted-types": "^2.0.7"
@@ -15008,7 +15008,7 @@
 			"integrity": "sha512-tGwo/hI+I3ewYLtkApr+twUQZWCS6Hq8rxQWCCXFTaUAdjoD5aU5aYWRdEazKddRD9NxCzQCftHz/GrCG5E6oQ==",
 			"dev": true,
 			"requires": {
-				"dompurify": "3.4.5",
+				"dompurify": "3.2.7",
 				"marked": "14.0.0"
 			}
 		},

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -3033,9 +3033,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
-			"integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+			"integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -4734,7 +4734,7 @@
 			"integrity": "sha512-+Xu2pWe4ypNQX7/ZMFF4M7VE8FP178LLVHYu7OO3ajoC80RsoI3sCj5tPlnumOua0DzTwEyk/PMNeiSl7VyAYw==",
 			"license": "MIT",
 			"dependencies": {
-				"dompurify": "3.4.5",
+				"dompurify": "3.2.7",
 				"marked": "14.0.0"
 			}
 		},


### PR DESCRIPTION
Reverts microsoft/monaco-editor#5333

I confirmed that DOMPurify 3.2.7 actually comes from microsoft/vscode.