### PR TITLE
Fix Perl regex quantifier tokenization

### DIFF
--- a/src/languages/definitions/perl/perl.test.ts
+++ b/src/languages/definitions/perl/perl.test.ts
@@ -329,6 +329,18 @@ testTokenization('perl', [
 		}
 	],
 
+	[
+		{
+			line: 'qr{\\\\W{1,10}}',
+			tokens: [
+				{ startIndex: 0, type: 'regexp.delim.perl' },
+				{ startIndex: 3, type: 'regexp.escape.perl' },
+				{ startIndex: 5, type: 'regexp.perl' },
+				{ startIndex: 12, type: 'regexp.delim.perl' }
+			]
+		}
+	],
+
 	// Operators
 	[
 		{

--- a/src/languages/definitions/perl/perl.ts
+++ b/src/languages/definitions/perl/perl.ts
@@ -603,6 +603,7 @@ export const language = <languages.IMonarchLanguage>{
 		qregexp: [
 			{ include: '@variables' },
 			[/\\./, 'regexp.escape'],
+			[/\{\d+(?:,\d*)?\}/, 'regexp'],
 			[
 				/./,
 				{


### PR DESCRIPTION
Fixes #4165

## Summary
- keep numeric regexp quantifiers like `{1,10}` as regexp content inside Perl quote-like regexp constructs
- add regression coverage for `qr{\\W{1,10}}` so the quantifier brace does not close the regexp early

## Verification
- `node --import tsx --import ./test/test-setup.mjs --test src/languages/definitions/perl/perl.test.ts`
- `npm run test:grammars`
- `npx ts-node ./build/check-samples`
- `npx prettier --check src/languages/definitions/perl/perl.ts src/languages/definitions/perl/perl.test.ts`
- `git diff --check`