### PR TITLE
Bump monaco-editor-core to 0.56.0-dev-20260629

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 				"jsdom": "^29.0.1",
 				"jsonc-parser": "^3.0.0",
 				"mocha": "^11.7.4",
-				"monaco-editor-core": "0.56.0-dev-20260625",
+				"monaco-editor-core": "0.56.0-dev-20260629",
 				"parcel": "^2.7.0",
 				"pin-github-action": "^1.8.0",
 				"postcss-url": "^10.1.3",
@@ -7152,9 +7152,9 @@
 			}
 		},
 		"node_modules/monaco-editor-core": {
-			"version": "0.56.0-dev-20260625",
-			"resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.56.0-dev-20260625.tgz",
-			"integrity": "sha512-U5tBhzC0okCZoJd1awWbh3cy2pqQlQndT7S1cHl50gC20DxXOeUdEBUr4DJPZ+FIoine3+ySqTNVLiVoso7xgw==",
+			"version": "0.56.0-dev-20260629",
+			"resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.56.0-dev-20260629.tgz",
+			"integrity": "sha512-G03gJu4FT3wcOG8CAEqcpLXt2oYV6Gy/f+fLiY3jA8nKBgsMRf18lnEH6bnK+Ri4m6HG6BEOHua+sHs9wKJGyg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -15012,9 +15012,9 @@
 			}
 		},
 		"monaco-editor-core": {
-			"version": "0.56.0-dev-20260625",
-			"resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.56.0-dev-20260625.tgz",
-			"integrity": "sha512-U5tBhzC0okCZoJd1awWbh3cy2pqQlQndT7S1cHl50gC20DxXOeUdEBUr4DJPZ+FIoine3+ySqTNVLiVoso7xgw==",
+			"version": "0.56.0-dev-20260629",
+			"resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.56.0-dev-20260629.tgz",
+			"integrity": "sha512-G03gJu4FT3wcOG8CAEqcpLXt2oYV6Gy/f+fLiY3jA8nKBgsMRf18lnEH6bnK+Ri4m6HG6BEOHua+sHs9wKJGyg==",
 			"dev": true,
 			"requires": {
 				"dompurify": "3.4.8",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 		"jsdom": "^29.0.1",
 		"jsonc-parser": "^3.0.0",
 		"mocha": "^11.7.4",
-		"monaco-editor-core": "0.56.0-dev-20260625",
+		"monaco-editor-core": "0.56.0-dev-20260629",
 		"parcel": "^2.7.0",
 		"pin-github-action": "^1.8.0",
 		"postcss-url": "^10.1.3",


### PR DESCRIPTION
Fixes: #5352
Fixes: #5314
Fixes: #5248

Not sure if there is tooling that should be used to do this instead or something, but this seems to do the trick.....

Bumps monaco-editor-core rather than trying to bump dompurify directly.