### PR TITLE
Release Monaco Editor 0.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Monaco Editor Changelog
 
+## [0.56.0]
+
+- Updates the editor core to the version used by `0.56.0-dev-20260625`.
+
 ## [0.55.1]
 
 - Fixes missing language exports (monaco.json/typescript/...) due to wrong "types" path - [#5123](https://github.com/microsoft/monaco-editor/issues/5123)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [0.56.0]
 
+### Breaking Changes
+
+- Reorganizes the exported ESM modules to provide supported, tree-shakeable entry points ([#5155](https://github.com/microsoft/monaco-editor/pull/5155)). The `monaco-editor` entry point continues to load all features and languages. Custom bundles can now import `monaco-editor/editor` and opt into:
+  - all editor features with `monaco-editor/features/register.all`, or individual features with `monaco-editor/features/<feature>/register`;
+  - all language definitions with `monaco-editor/languages/definitions/register.all`, or individual definitions with `monaco-editor/languages/definitions/<language>/register`;
+  - the CSS, HTML, JSON, and TypeScript language features with `monaco-editor/languages/features/register.all`, or their individual `register` entry points.
+- Renames the misspelled `IOverlayWidgetPosition.stackOridinal` property to `stackOrdinal`.
+- Removes the deprecated `IMirrorModel` and `IWorkerContext` worker API types.
+
+### New Features and APIs
+
+- Adds `editor.doubleClickSelectsBlock`.
+- Adds `editor.find.closeOnResult` and `editor.inlayHints.showLongLineWarning`.
+- Adds `offWhenInlineCompletions` to `QuickSuggestionsValue`.
+- Adds model and provider option support to inline completion providers.
+- Adds `ICodeEditor.revealAllCursors`, `ICodeEditor.getWidthOfLine`, and `ICodeEditor.renderAsync`.
+- Adds `advanced-external` and `advanced-wasm` diff algorithms.
+- Exposes typed native LSP client and transport APIs.
+
+### Fixes
+
+- Treats Markdown returned by language servers as untrusted ([#5280](https://github.com/microsoft/monaco-editor/pull/5280)).
 - Updates the editor core to the version used by `0.56.0-dev-20260625`.
 
 ## [0.55.1]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "monaco-editor",
-	"version": "0.55.1",
+	"version": "0.56.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "monaco-editor",
-			"version": "0.55.1",
+			"version": "0.56.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"devDependencies": {
@@ -29,7 +29,7 @@
 				"jsdom": "^29.0.1",
 				"jsonc-parser": "^3.0.0",
 				"mocha": "^11.7.4",
-				"monaco-editor-core": "0.56.0-dev-20260203",
+				"monaco-editor-core": "0.56.0-dev-20260625",
 				"parcel": "^2.7.0",
 				"pin-github-action": "^1.8.0",
 				"postcss-url": "^10.1.3",
@@ -5172,9 +5172,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-			"integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+			"version": "3.4.8",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+			"integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
 			"dev": true,
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
@@ -7152,13 +7152,13 @@
 			}
 		},
 		"node_modules/monaco-editor-core": {
-			"version": "0.56.0-dev-20260203",
-			"resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.56.0-dev-20260203.tgz",
-			"integrity": "sha512-tGwo/hI+I3ewYLtkApr+twUQZWCS6Hq8rxQWCCXFTaUAdjoD5aU5aYWRdEazKddRD9NxCzQCftHz/GrCG5E6oQ==",
+			"version": "0.56.0-dev-20260625",
+			"resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.56.0-dev-20260625.tgz",
+			"integrity": "sha512-U5tBhzC0okCZoJd1awWbh3cy2pqQlQndT7S1cHl50gC20DxXOeUdEBUr4DJPZ+FIoine3+ySqTNVLiVoso7xgw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"dompurify": "3.2.7",
+				"dompurify": "3.4.8",
 				"marked": "14.0.0"
 			}
 		},
@@ -13743,9 +13743,9 @@
 			"dev": true
 		},
 		"dompurify": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-			"integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+			"version": "3.4.8",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+			"integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
 			"dev": true,
 			"requires": {
 				"@types/trusted-types": "^2.0.7"
@@ -15012,12 +15012,12 @@
 			}
 		},
 		"monaco-editor-core": {
-			"version": "0.56.0-dev-20260203",
-			"resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.56.0-dev-20260203.tgz",
-			"integrity": "sha512-tGwo/hI+I3ewYLtkApr+twUQZWCS6Hq8rxQWCCXFTaUAdjoD5aU5aYWRdEazKddRD9NxCzQCftHz/GrCG5E6oQ==",
+			"version": "0.56.0-dev-20260625",
+			"resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.56.0-dev-20260625.tgz",
+			"integrity": "sha512-U5tBhzC0okCZoJd1awWbh3cy2pqQlQndT7S1cHl50gC20DxXOeUdEBUr4DJPZ+FIoine3+ySqTNVLiVoso7xgw==",
 			"dev": true,
 			"requires": {
-				"dompurify": "3.2.7",
+				"dompurify": "3.4.8",
 				"marked": "14.0.0"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "monaco-editor",
-	"version": "0.55.1",
-	"vscodeRef": "86f5a62f058e3905f74a9fa65d04b2f3b533408e",
+	"version": "0.56.0",
+	"vscodeRef": "f487add297079a02eb836810185b165e50cadabc",
 	"private": true,
 	"description": "A browser based code editor",
 	"homepage": "https://github.com/microsoft/monaco-editor",
@@ -70,7 +70,7 @@
 		"jsdom": "^29.0.1",
 		"jsonc-parser": "^3.0.0",
 		"mocha": "^11.7.4",
-		"monaco-editor-core": "0.56.0-dev-20260203",
+		"monaco-editor-core": "0.56.0-dev-20260625",
 		"parcel": "^2.7.0",
 		"pin-github-action": "^1.8.0",
 		"postcss-url": "^10.1.3",


### PR DESCRIPTION
Promotes the latest published nightly (`0.56.0-dev-20260625`) to stable `0.56.0`.

- Uses Monaco commit `d8c9ff06b7bcbd0c07d1ccb16e3d30f5e5962d08`
- Uses VS Code commit `f487add297079a02eb836810185b165e50cadabc`
- Updates `monaco-editor-core` to `0.56.0-dev-20260625`
- Updates the lockfile and changelog
