### PR TITLE
Fix find widget hover flickering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Monaco Editor Changelog
 
+## [0.56.1]
+
+- Fixes find widget hover flickering when the editor container has a static position ([#5296](https://github.com/microsoft/monaco-editor/issues/5296)).
+
 ## [0.56.0]
 
 ### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "monaco-editor",
-	"version": "0.56.0",
+	"version": "0.56.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "monaco-editor",
-			"version": "0.56.0",
+			"version": "0.56.1",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "monaco-editor",
-	"version": "0.56.0",
-	"vscodeRef": "f487add297079a02eb836810185b165e50cadabc",
+	"version": "0.56.1",
+	"vscodeRef": "e347ab9e055324ab6b2d4cbe352a3a1ba8bc6d82",
 	"private": true,
 	"description": "A browser based code editor",
 	"homepage": "https://github.com/microsoft/monaco-editor",


### PR DESCRIPTION
### Motivation
- Fixes #5296.
### Before
- Find widget action hovers flicker when an unpositioned editor container follows other page content.
### After
- Release 0.56.1 builds Monaco core from the validated ContextView positioning fix, keeping hover overlays anchored to their actual containing block.