### PR TITLE
Fix bundled editor CSS package export

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 			"import": "./esm/vs/index.js",
 			"require": "./min/vs/index.js"
 		},
+		"./min/vs/editor/editor.main.css": "./min/vs/editor/editor.main.css",
 		"./*.js": "./esm/vs/*.js",
 		"./*": "./esm/vs/*.js"
 	},

--- a/test/smoke/esbuild/editor-main-css.js
+++ b/test/smoke/esbuild/editor-main-css.js
@@ -1,0 +1,6 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'monaco-editor/min/vs/editor/editor.main.css';

--- a/test/smoke/package-esbuild.ts
+++ b/test/smoke/package-esbuild.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as esbuild from 'esbuild';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { removeDir } from '../../build/fs';
 
@@ -34,6 +36,23 @@ build({
 	format: 'iife',
 	logLevel: 'silent',
 	outdir: path.join(__dirname, 'esbuild/out'),
+	loader: {
+		'.ttf': 'file'
+	}
+});
+
+build({
+	stdin: {
+		contents: fs.readFileSync(path.join(__dirname, 'esbuild/editor-main-css.js'), 'utf8'),
+		// Resolve outside this package so the bare import exercises the generated package exports.
+		resolveDir: os.tmpdir(),
+		sourcefile: 'editor-main-css.js'
+	},
+	bundle: true,
+	format: 'iife',
+	logLevel: 'silent',
+	outdir: path.join(__dirname, 'esbuild/out'),
+	nodePaths: [path.join(__dirname, '../../out')],
 	loader: {
 		'.ttf': 'file'
 	}


### PR DESCRIPTION
## Summary

- export the existing bundled editor stylesheet through the package exports map
- add an esbuild smoke regression that resolves the CSS from the generated package

## Tests

- `npm run build-lsp`
- `npm run build-monaco-editor`
- `npm test`
- `npm run compile --prefix webpack-plugin`
- `npm run package-for-smoketest`
- `npx prettier --check package.json test/smoke/package-esbuild.ts test/smoke/esbuild/editor-main-css.js`

Fixes #5404
